### PR TITLE
feat: upgrade-send-coin

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -463,7 +463,7 @@ func New(
 
 	// <sunrise>
 	// Step 8: Set the custom Upgrade handler on BaseApp. This is added for on-chain upgrade.
-	app.setupUpgradeHandlers()
+	app.setupUpgradeHandlers(appConfig)
 	// Step 9: Set the custom upgrade store loaders on BaseApp.
 	app.setupUpgradeStoreLoaders()
 	// </sunrise>
@@ -656,7 +656,7 @@ func (app *App) setupUpgradeStoreLoaders() {
 	}
 }
 
-func (app *App) setupUpgradeHandlers() {
+func (app *App) setupUpgradeHandlers(appConfig depinject.Config) {
 	appKeepers := keepers.AppKeepers{
 		// keepers
 		AccountKeeper:         app.AccountKeeper,

--- a/app/app.go
+++ b/app/app.go
@@ -700,17 +700,12 @@ func (app *App) setupUpgradeHandlers(appConfig depinject.Config) {
 		SwapKeeper:               app.SwapKeeper,
 		FeeKeeper:                app.FeeKeeper,
 	}
-	var mm *module.Manager
-	var configurator module.Configurator
-	if err := depinject.Inject(appConfig, mm, configurator); err != nil {
-		panic(err)
-	}
 	for _, upgrade := range Upgrades {
 		app.UpgradeKeeper.SetUpgradeHandler(
 			upgrade.UpgradeName,
 			upgrade.CreateUpgradeHandler(
-				mm,
-				configurator,
+				app.ModuleManager,
+				app.Configurator(),
 				&appKeepers,
 			),
 		)

--- a/app/app.go
+++ b/app/app.go
@@ -463,7 +463,7 @@ func New(
 
 	// <sunrise>
 	// Step 8: Set the custom Upgrade handler on BaseApp. This is added for on-chain upgrade.
-	app.setupUpgradeHandlers(appConfig)
+	app.setupUpgradeHandlers()
 	// Step 9: Set the custom upgrade store loaders on BaseApp.
 	app.setupUpgradeStoreLoaders()
 	// </sunrise>
@@ -656,7 +656,7 @@ func (app *App) setupUpgradeStoreLoaders() {
 	}
 }
 
-func (app *App) setupUpgradeHandlers(appConfig depinject.Config) {
+func (app *App) setupUpgradeHandlers() {
 	appKeepers := keepers.AppKeepers{
 		// keepers
 		AccountKeeper:         app.AccountKeeper,

--- a/app/app.go
+++ b/app/app.go
@@ -169,14 +169,6 @@ type App struct {
 	// simulation manager
 	sm *module.SimulationManager
 
-	// <sunrise>
-	// the module manager
-	mm *module.Manager
-
-	// module configurator
-	configurator module.Configurator
-	// </sunrise>
-
 	// custom structure for skip-mev protection
 	MevLane        *mevlane.MEVLane
 	CheckTxHandler checktx.CheckTx
@@ -711,8 +703,8 @@ func (app *App) SetupUpgradeHandlers() {
 		app.UpgradeKeeper.SetUpgradeHandler(
 			upgrade.UpgradeName,
 			upgrade.CreateUpgradeHandler(
-				app.mm,
-				app.configurator,
+				app.ModuleManager,
+				app.Configurator(),
 				app.BaseApp,
 				&appKeepers,
 			),

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -8,10 +9,7 @@ import (
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
-	circuitkeeper "cosmossdk.io/x/circuit/keeper"
-	evidencekeeper "cosmossdk.io/x/evidence/keeper"
-	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
-	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -25,32 +23,16 @@ import (
 	testdata_pulsar "github.com/cosmos/cosmos-sdk/testutil/testdata/testpb"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
-	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
-	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
-	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	groupkeeper "github.com/cosmos/cosmos-sdk/x/group/keeper"
-	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
-	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
-	icacontrollerkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/keeper"
-	icahostkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/keeper"
-	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
-	ibctransferkeeper "github.com/cosmos/ibc-go/v8/modules/apps/transfer/keeper"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	"github.com/skip-mev/block-sdk/v2/abci"
 	"github.com/skip-mev/block-sdk/v2/abci/checktx"
@@ -58,7 +40,6 @@ import (
 	"github.com/skip-mev/block-sdk/v2/block/base"
 	"github.com/skip-mev/block-sdk/v2/block/service"
 	mevlane "github.com/skip-mev/block-sdk/v2/lanes/mev"
-	auctionkeeper "github.com/skip-mev/block-sdk/v2/x/auction/keeper"
 	"github.com/sunriselayer/sunrise/app/ante"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -69,16 +50,11 @@ import (
 	feetypes "github.com/sunriselayer/sunrise/x/fee/types"
 	tokenconvertertypes "github.com/sunriselayer/sunrise/x/tokenconverter/types"
 
-	blobmodulekeeper "github.com/sunriselayer/sunrise/x/blob/keeper"
-	streammodulekeeper "github.com/sunriselayer/sunrise/x/blobstream/keeper"
-	feemodulekeeper "github.com/sunriselayer/sunrise/x/fee/keeper"
-	liquidityincentivemodulekeeper "github.com/sunriselayer/sunrise/x/liquidityincentive/keeper"
-	liquiditypoolmodulekeeper "github.com/sunriselayer/sunrise/x/liquiditypool/keeper"
-	swapmodulekeeper "github.com/sunriselayer/sunrise/x/swap/keeper"
-	tokenconvertermodulekeeper "github.com/sunriselayer/sunrise/x/tokenconverter/keeper"
-
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
+	"github.com/sunriselayer/sunrise/app/keepers"
+	"github.com/sunriselayer/sunrise/app/upgrades"
+	v0_1_5_test "github.com/sunriselayer/sunrise/app/upgrades/v0.1.5-test"
 	"github.com/sunriselayer/sunrise/docs"
 )
 
@@ -97,6 +73,10 @@ const (
 var (
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
+
+	// <sunrise>
+	Upgrades = []upgrades.Upgrade{v0_1_5_test.Upgrade}
+	// </sunrise>
 )
 
 var (
@@ -109,53 +89,22 @@ var (
 // capabilities aren't needed for testing.
 type App struct {
 	*runtime.App
+	// <sunrise>
+	keepers.AppKeepers
+	// <sunrise>
 	legacyAmino       *codec.LegacyAmino
 	appCodec          codec.Codec
 	txConfig          client.TxConfig
 	interfaceRegistry codectypes.InterfaceRegistry
-
-	// keepers
-	AccountKeeper         authkeeper.AccountKeeper
-	BankKeeper            bankkeeper.Keeper
-	StakingKeeper         *stakingkeeper.Keeper
-	SlashingKeeper        slashingkeeper.Keeper
-	MintKeeper            mintkeeper.Keeper
-	DistrKeeper           distrkeeper.Keeper
-	GovKeeper             *govkeeper.Keeper
-	CrisisKeeper          *crisiskeeper.Keeper
-	UpgradeKeeper         *upgradekeeper.Keeper
-	ParamsKeeper          paramskeeper.Keeper
-	AuthzKeeper           authzkeeper.Keeper
-	EvidenceKeeper        evidencekeeper.Keeper
-	FeeGrantKeeper        feegrantkeeper.Keeper
-	GroupKeeper           groupkeeper.Keeper
-	ConsensusParamsKeeper consensuskeeper.Keeper
-	CircuitBreakerKeeper  circuitkeeper.Keeper
-
-	// IBC
-	IBCKeeper           *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-	CapabilityKeeper    *capabilitykeeper.Keeper
-	IBCFeeKeeper        ibcfeekeeper.Keeper
-	ICAControllerKeeper icacontrollerkeeper.Keeper
-	ICAHostKeeper       icahostkeeper.Keeper
-	TransferKeeper      ibctransferkeeper.Keeper
-
-	// Scoped IBC
-	ScopedIBCKeeper           capabilitykeeper.ScopedKeeper
-	ScopedIBCTransferKeeper   capabilitykeeper.ScopedKeeper
-	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
-	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
-
-	// Third party module keepers
-	AuctionKeeper            auctionkeeper.Keeper
-	BlobKeeper               blobmodulekeeper.Keeper
-	StreamKeeper             streammodulekeeper.Keeper
-	TokenconverterKeeper     tokenconvertermodulekeeper.Keeper
-	LiquiditypoolKeeper      liquiditypoolmodulekeeper.Keeper
-	LiquidityincentiveKeeper liquidityincentivemodulekeeper.Keeper
-	SwapKeeper               swapmodulekeeper.Keeper
-	FeeKeeper                feemodulekeeper.Keeper
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
+
+	// <sunrise>
+	// the module manager
+	mm *module.Manager
+
+	// module configurator
+	configurator module.Configurator
+	// </sunrise>
 
 	// simulation manager
 	sm *module.SimulationManager
@@ -294,32 +243,32 @@ func New(
 		&app.legacyAmino,
 		&app.txConfig,
 		&app.interfaceRegistry,
-		&app.AccountKeeper,
-		&app.BankKeeper,
-		&app.StakingKeeper,
-		&app.SlashingKeeper,
-		&app.MintKeeper,
-		&app.DistrKeeper,
-		&app.GovKeeper,
-		&app.CrisisKeeper,
-		&app.UpgradeKeeper,
-		&app.ParamsKeeper,
-		&app.AuthzKeeper,
-		&app.EvidenceKeeper,
-		&app.FeeGrantKeeper,
-		&app.GroupKeeper,
-		&app.ConsensusParamsKeeper,
-		&app.CircuitBreakerKeeper,
+		&app.AppKeepers.AccountKeeper,
+		&app.AppKeepers.BankKeeper,
+		&app.AppKeepers.StakingKeeper,
+		&app.AppKeepers.SlashingKeeper,
+		&app.AppKeepers.MintKeeper,
+		&app.AppKeepers.DistrKeeper,
+		&app.AppKeepers.GovKeeper,
+		&app.AppKeepers.CrisisKeeper,
+		&app.AppKeepers.UpgradeKeeper,
+		&app.AppKeepers.ParamsKeeper,
+		&app.AppKeepers.AuthzKeeper,
+		&app.AppKeepers.EvidenceKeeper,
+		&app.AppKeepers.FeeGrantKeeper,
+		&app.AppKeepers.GroupKeeper,
+		&app.AppKeepers.ConsensusParamsKeeper,
+		&app.AppKeepers.CircuitBreakerKeeper,
 
 		// Third party module keepers
-		&app.AuctionKeeper,
-		&app.BlobKeeper,
-		&app.StreamKeeper,
-		&app.TokenconverterKeeper,
-		&app.LiquiditypoolKeeper,
-		&app.LiquidityincentiveKeeper,
-		&app.SwapKeeper,
-		&app.FeeKeeper,
+		&app.AppKeepers.AuctionKeeper,
+		&app.AppKeepers.BlobKeeper,
+		&app.AppKeepers.StreamKeeper,
+		&app.AppKeepers.TokenconverterKeeper,
+		&app.AppKeepers.LiquiditypoolKeeper,
+		&app.AppKeepers.LiquidityincentiveKeeper,
+		&app.AppKeepers.SwapKeeper,
+		&app.AppKeepers.FeeKeeper,
 		// this line is used by starport scaffolding # stargate/app/keeperDefinition
 	); err != nil {
 		panic(err)
@@ -363,7 +312,7 @@ func New(
 	app.registerIBCModules()
 
 	// <sunrise>
-	app.SwapKeeper.TransferKeeper = &app.TransferKeeper
+	app.AppKeepers.SwapKeeper.TransferKeeper = &app.AppKeepers.TransferKeeper
 	// </sunrise>
 
 	// register streaming services
@@ -397,15 +346,15 @@ func New(
 	// proposals are being built and verified. Note that this step must be done before
 	// setting the ante handler on the lanes.
 	anteHandler := ante.NewAnteHandler(
-		app.AccountKeeper,
-		app.BankKeeper,
-		app.FeeGrantKeeper,
-		app.BlobKeeper,
-		app.FeeKeeper,
+		app.AppKeepers.AccountKeeper,
+		app.AppKeepers.BankKeeper,
+		app.AppKeepers.FeeGrantKeeper,
+		app.AppKeepers.BlobKeeper,
+		app.AppKeepers.FeeKeeper,
 		app.txConfig.SignModeHandler(),
 		ante.DefaultSigVerificationGasConsumer,
-		app.IBCKeeper,
-		app.AuctionKeeper,
+		app.AppKeepers.IBCKeeper,
+		app.AppKeepers.AuctionKeeper,
 		mevLane,
 		app.txConfig.TxEncoder(),
 	)
@@ -451,11 +400,19 @@ func New(
 	)
 
 	app.SetCheckTx(checkTxHandler.CheckTx())
+
+	// <sunrise>
+	// Step 8: Set the custom Upgrade handler on BaseApp. This is added for on-chain upgrade.
+	app.SetupUpgradeHandlers()
+	// Step 8: Set the custom upgrade store loaders on BaseApp.
+	app.SetupUpgradeStoreLoaders()
+	// </sunrise>
+
 	// ---------------------------------------------------------------------------- //
 	// ------------------------- End `Skip MEV` Code ------------------------------ //
 	// ---------------------------------------------------------------------------- //
 
-	app.ModuleManager.RegisterInvariants(app.CrisisKeeper)
+	app.ModuleManager.RegisterInvariants(app.AppKeepers.CrisisKeeper)
 
 	// add test gRPC service for testing gRPC queries in isolation
 	testdata_pulsar.RegisterQueryServer(app.GRPCQueryRouter(), testdata_pulsar.QueryImpl{})
@@ -465,7 +422,7 @@ func New(
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing
 	// transactions
 	overrideModules := map[string]module.AppModuleSimulation{
-		authtypes.ModuleName: auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
+		authtypes.ModuleName: auth.NewAppModule(app.appCodec, app.AppKeepers.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
 	}
 	app.sm = module.NewSimulationManagerFromAppModules(app.ModuleManager.Modules, overrideModules)
 
@@ -538,7 +495,7 @@ func (app *App) kvStoreKeys() map[string]*storetypes.KVStoreKey {
 
 // GetSubspace returns a param subspace for a given module name.
 func (app *App) GetSubspace(moduleName string) paramstypes.Subspace {
-	subspace, _ := app.ParamsKeeper.GetSubspace(moduleName)
+	subspace, _ := app.AppKeepers.ParamsKeeper.GetSubspace(moduleName)
 	return subspace
 }
 
@@ -580,12 +537,12 @@ func (app *App) RegisterTxService(clientCtx client.Context) {
 
 // GetIBCKeeper returns the IBC keeper.
 func (app *App) GetIBCKeeper() *ibckeeper.Keeper {
-	return app.IBCKeeper
+	return app.AppKeepers.IBCKeeper
 }
 
 // GetCapabilityScopedKeeper returns the capability scoped keeper.
 func (app *App) GetCapabilityScopedKeeper(moduleName string) capabilitykeeper.ScopedKeeper {
-	return app.CapabilityKeeper.ScopeToModule(moduleName)
+	return app.AppKeepers.CapabilityKeeper.ScopeToModule(moduleName)
 }
 
 // GetMaccPerms returns a copy of the module account permissions
@@ -617,4 +574,36 @@ func BlockedAddresses() map[string]bool {
 // GetTxConfig implements the TestingApp interface.
 func (app *App) GetTxConfig() client.TxConfig {
 	return app.txConfig
+}
+
+func (app *App) SetupUpgradeStoreLoaders() {
+	upgradeInfo, err := app.AppKeepers.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
+	}
+
+	if app.AppKeepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		return
+	}
+
+	for _, upgrade := range Upgrades {
+		if upgradeInfo.Name == upgrade.UpgradeName {
+			app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &upgrade.StoreUpgrades))
+		}
+	}
+
+}
+
+func (app *App) SetupUpgradeHandlers() {
+	for _, upgrade := range Upgrades {
+		app.AppKeepers.UpgradeKeeper.SetUpgradeHandler(
+			upgrade.UpgradeName,
+			upgrade.CreateUpgradeHandler(
+				app.mm,
+				app.configurator,
+				app.BaseApp,
+				&app.AppKeepers,
+			),
+		)
+	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -60,6 +62,9 @@ import (
 	mevlane "github.com/skip-mev/block-sdk/v2/lanes/mev"
 	auctionkeeper "github.com/skip-mev/block-sdk/v2/x/auction/keeper"
 	"github.com/sunriselayer/sunrise/app/ante"
+	"github.com/sunriselayer/sunrise/app/keepers"
+	"github.com/sunriselayer/sunrise/app/upgrades"
+	v0_1_5_test "github.com/sunriselayer/sunrise/app/upgrades/v0.1.5-test"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
@@ -97,6 +102,10 @@ const (
 var (
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
+
+	// <sunrise>
+	Upgrades = []upgrades.Upgrade{v0_1_5_test.Upgrade}
+	// </sunrise>
 )
 
 var (
@@ -159,6 +168,14 @@ type App struct {
 
 	// simulation manager
 	sm *module.SimulationManager
+
+	// <sunrise>
+	// the module manager
+	mm *module.Manager
+
+	// module configurator
+	configurator module.Configurator
+	// </sunrise>
 
 	// custom structure for skip-mev protection
 	MevLane        *mevlane.MEVLane
@@ -451,6 +468,14 @@ func New(
 	)
 
 	app.SetCheckTx(checkTxHandler.CheckTx())
+
+	// <sunrise>
+	// Step 8: Set the custom Upgrade handler on BaseApp. This is added for on-chain upgrade.
+	app.SetupUpgradeHandlers()
+	// Step 9: Set the custom upgrade store loaders on BaseApp.
+	app.SetupUpgradeStoreLoaders()
+	// </sunrise>
+
 	// ---------------------------------------------------------------------------- //
 	// ------------------------- End `Skip MEV` Code ------------------------------ //
 	// ---------------------------------------------------------------------------- //
@@ -618,3 +643,81 @@ func BlockedAddresses() map[string]bool {
 func (app *App) GetTxConfig() client.TxConfig {
 	return app.txConfig
 }
+
+// <sunrise>
+func (app *App) SetupUpgradeStoreLoaders() {
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
+	}
+
+	if app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		return
+	}
+
+	for _, upgrade := range Upgrades {
+		if upgradeInfo.Name == upgrade.UpgradeName {
+			app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &upgrade.StoreUpgrades))
+		}
+	}
+
+}
+
+func (app *App) SetupUpgradeHandlers() {
+	appKeepers := keepers.AppKeepers{
+		// keepers
+		AccountKeeper:         app.AccountKeeper,
+		BankKeeper:            app.BankKeeper,
+		StakingKeeper:         app.StakingKeeper,
+		SlashingKeeper:        app.SlashingKeeper,
+		MintKeeper:            app.MintKeeper,
+		DistrKeeper:           app.DistrKeeper,
+		GovKeeper:             app.GovKeeper,
+		CrisisKeeper:          app.CrisisKeeper,
+		UpgradeKeeper:         app.UpgradeKeeper,
+		ParamsKeeper:          app.ParamsKeeper,
+		AuthzKeeper:           app.AuthzKeeper,
+		EvidenceKeeper:        app.EvidenceKeeper,
+		FeeGrantKeeper:        app.FeeGrantKeeper,
+		GroupKeeper:           app.GroupKeeper,
+		ConsensusParamsKeeper: app.ConsensusParamsKeeper,
+		CircuitBreakerKeeper:  app.CircuitBreakerKeeper,
+
+		// IBC
+		IBCKeeper:           app.IBCKeeper,
+		CapabilityKeeper:    app.CapabilityKeeper,
+		IBCFeeKeeper:        app.IBCFeeKeeper,
+		ICAControllerKeeper: app.ICAControllerKeeper,
+		ICAHostKeeper:       app.ICAHostKeeper,
+		TransferKeeper:      app.TransferKeeper,
+
+		// Scoped IBC
+		ScopedIBCKeeper:           app.ScopedIBCKeeper,
+		ScopedIBCTransferKeeper:   app.ScopedIBCTransferKeeper,
+		ScopedICAControllerKeeper: app.ScopedICAControllerKeeper,
+		ScopedICAHostKeeper:       app.ScopedICAHostKeeper,
+
+		// Third party module keepers
+		AuctionKeeper:            app.AuctionKeeper,
+		BlobKeeper:               app.BlobKeeper,
+		StreamKeeper:             app.StreamKeeper,
+		TokenconverterKeeper:     app.TokenconverterKeeper,
+		LiquiditypoolKeeper:      app.LiquiditypoolKeeper,
+		LiquidityincentiveKeeper: app.LiquidityincentiveKeeper,
+		SwapKeeper:               app.SwapKeeper,
+		FeeKeeper:                app.FeeKeeper,
+	}
+	for _, upgrade := range Upgrades {
+		app.UpgradeKeeper.SetUpgradeHandler(
+			upgrade.UpgradeName,
+			upgrade.CreateUpgradeHandler(
+				app.mm,
+				app.configurator,
+				app.BaseApp,
+				&appKeepers,
+			),
+		)
+	}
+}
+
+// </sunrise>

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -1,0 +1,80 @@
+package keepers
+
+import (
+	circuitkeeper "cosmossdk.io/x/circuit/keeper"
+	evidencekeeper "cosmossdk.io/x/evidence/keeper"
+	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
+	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	groupkeeper "github.com/cosmos/cosmos-sdk/x/group/keeper"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
+	icacontrollerkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/keeper"
+	icahostkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/keeper"
+	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v8/modules/apps/transfer/keeper"
+	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
+	auctionkeeper "github.com/skip-mev/block-sdk/v2/x/auction/keeper"
+
+	blobmodulekeeper "github.com/sunriselayer/sunrise/x/blob/keeper"
+	streammodulekeeper "github.com/sunriselayer/sunrise/x/blobstream/keeper"
+	feemodulekeeper "github.com/sunriselayer/sunrise/x/fee/keeper"
+	liquidityincentivemodulekeeper "github.com/sunriselayer/sunrise/x/liquidityincentive/keeper"
+	liquiditypoolmodulekeeper "github.com/sunriselayer/sunrise/x/liquiditypool/keeper"
+	swapmodulekeeper "github.com/sunriselayer/sunrise/x/swap/keeper"
+	tokenconvertermodulekeeper "github.com/sunriselayer/sunrise/x/tokenconverter/keeper"
+)
+
+type AppKeepers struct {
+	// keepers, by order of initialization
+	// keepers
+	AccountKeeper         authkeeper.AccountKeeper
+	BankKeeper            bankkeeper.Keeper
+	StakingKeeper         *stakingkeeper.Keeper
+	SlashingKeeper        slashingkeeper.Keeper
+	MintKeeper            mintkeeper.Keeper
+	DistrKeeper           distrkeeper.Keeper
+	GovKeeper             *govkeeper.Keeper
+	CrisisKeeper          *crisiskeeper.Keeper
+	UpgradeKeeper         *upgradekeeper.Keeper
+	ParamsKeeper          paramskeeper.Keeper
+	AuthzKeeper           authzkeeper.Keeper
+	EvidenceKeeper        evidencekeeper.Keeper
+	FeeGrantKeeper        feegrantkeeper.Keeper
+	GroupKeeper           groupkeeper.Keeper
+	ConsensusParamsKeeper consensuskeeper.Keeper
+	CircuitBreakerKeeper  circuitkeeper.Keeper
+
+	// IBC
+	IBCKeeper           *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	CapabilityKeeper    *capabilitykeeper.Keeper
+	IBCFeeKeeper        ibcfeekeeper.Keeper
+	ICAControllerKeeper icacontrollerkeeper.Keeper
+	ICAHostKeeper       icahostkeeper.Keeper
+	TransferKeeper      ibctransferkeeper.Keeper
+
+	// Scoped IBC
+	ScopedIBCKeeper           capabilitykeeper.ScopedKeeper
+	ScopedIBCTransferKeeper   capabilitykeeper.ScopedKeeper
+	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
+	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
+
+	// Third party module keepers
+	AuctionKeeper            auctionkeeper.Keeper
+	BlobKeeper               blobmodulekeeper.Keeper
+	StreamKeeper             streammodulekeeper.Keeper
+	TokenconverterKeeper     tokenconvertermodulekeeper.Keeper
+	LiquiditypoolKeeper      liquiditypoolmodulekeeper.Keeper
+	LiquidityincentiveKeeper liquidityincentivemodulekeeper.Keeper
+	SwapKeeper               swapmodulekeeper.Keeper
+	FeeKeeper                feemodulekeeper.Keeper
+}

--- a/app/upgrades/README.md
+++ b/app/upgrades/README.md
@@ -1,0 +1,7 @@
+# Sunrise Upgrades
+
+## Testnet
+
+### v0.1.5-test
+
+- sendCoin vRISE to new validators

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -25,7 +25,7 @@ type Upgrade struct {
 	UpgradeName string
 
 	// CreateUpgradeHandler defines the function that creates an upgrade handler
-	CreateUpgradeHandler func(*module.Manager, module.Configurator, BaseAppParamManager, *keepers.AppKeepers) upgradetypes.UpgradeHandler
+	CreateUpgradeHandler func(*module.Manager, module.Configurator, *keepers.AppKeepers) upgradetypes.UpgradeHandler
 
 	// Store upgrades, should be used for any new modules introduced, new modules deleted, or store names renamed.
 	StoreUpgrades storetypes.StoreUpgrades

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -1,0 +1,47 @@
+package upgrades
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/sunriselayer/sunrise/app"
+)
+
+// BaseAppParamManager defines an interrace that BaseApp is expected to fullfil
+// that allows upgrade handlers to modify BaseApp parameters.
+type BaseAppParamManager interface {
+	GetConsensusParams(ctx sdk.Context) *tmproto.ConsensusParams
+	StoreConsensusParams(ctx sdk.Context, cp *tmproto.ConsensusParams)
+}
+
+// Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal
+// must have written, in order for the state migration to go smoothly.
+// An upgrade must implement this struct, and then set it in the app.go.
+// The app.go will then define the handler.
+type Upgrade struct {
+	// Upgrade version name, for the upgrade handler, e.g. `v7`
+	UpgradeName string
+
+	// CreateUpgradeHandler defines the function that creates an upgrade handler
+	CreateUpgradeHandler func(*module.Manager, module.Configurator, BaseAppParamManager, *app.App) upgradetypes.UpgradeHandler
+
+	// Store upgrades, should be used for any new modules introduced, new modules deleted, or store names renamed.
+	StoreUpgrades storetypes.StoreUpgrades
+}
+
+// Fork defines a struct containing the requisite fields for a non-software upgrade proposal
+// Hard Fork at a given height to implement.
+// There is one time code that can be added for the start of the Fork, in `BeginForkLogic`.
+// Any other change in the code should be height-gated, if the goal is to have old and new binaries
+// to be compatible prior to the upgrade height.
+type Fork struct {
+	// Upgrade version name, for the upgrade handler, e.g. `v7`
+	UpgradeName string
+	// height the upgrade occurs at
+	UpgradeHeight int64
+
+	// Function that runs some custom state transition code at the beginning of a fork.
+	BeginForkLogic func(ctx sdk.Context, app *app.App)
+}

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -6,14 +6,14 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/sunriselayer/sunrise/app"
+	"github.com/sunriselayer/sunrise/app/keepers"
 )
 
 // BaseAppParamManager defines an interrace that BaseApp is expected to fullfil
 // that allows upgrade handlers to modify BaseApp parameters.
 type BaseAppParamManager interface {
-	GetConsensusParams(ctx sdk.Context) *tmproto.ConsensusParams
-	StoreConsensusParams(ctx sdk.Context, cp *tmproto.ConsensusParams)
+	GetConsensusParams(ctx sdk.Context) tmproto.ConsensusParams
+	StoreConsensusParams(ctx sdk.Context, cp tmproto.ConsensusParams) error
 }
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal
@@ -25,7 +25,7 @@ type Upgrade struct {
 	UpgradeName string
 
 	// CreateUpgradeHandler defines the function that creates an upgrade handler
-	CreateUpgradeHandler func(*module.Manager, module.Configurator, BaseAppParamManager, *app.App) upgradetypes.UpgradeHandler
+	CreateUpgradeHandler func(*module.Manager, module.Configurator, BaseAppParamManager, *keepers.AppKeepers) upgradetypes.UpgradeHandler
 
 	// Store upgrades, should be used for any new modules introduced, new modules deleted, or store names renamed.
 	StoreUpgrades storetypes.StoreUpgrades
@@ -43,5 +43,5 @@ type Fork struct {
 	UpgradeHeight int64
 
 	// Function that runs some custom state transition code at the beginning of a fork.
-	BeginForkLogic func(ctx sdk.Context, app *app.App)
+	BeginForkLogic func(ctx sdk.Context, keepers *keepers.AppKeepers)
 }

--- a/app/upgrades/v0.1.5-test/constants.go
+++ b/app/upgrades/v0.1.5-test/constants.go
@@ -13,6 +13,6 @@ var Upgrade = upgrades.Upgrade{
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: storetypes.StoreUpgrades{
 		Added:   []string{},
-		Deleted: []string{"capability"},
+		Deleted: []string{},
 	},
 }

--- a/app/upgrades/v0.1.5-test/constants.go
+++ b/app/upgrades/v0.1.5-test/constants.go
@@ -1,0 +1,18 @@
+package v0_1_5_test
+
+import (
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/sunriselayer/sunrise/app/upgrades"
+)
+
+const UpgradeName string = "v0_1_5_test"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}

--- a/app/upgrades/v0.1.5-test/constants.go
+++ b/app/upgrades/v0.1.5-test/constants.go
@@ -13,6 +13,6 @@ var Upgrade = upgrades.Upgrade{
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: storetypes.StoreUpgrades{
 		Added:   []string{},
-		Deleted: []string{},
+		Deleted: []string{"capability"},
 	},
 }

--- a/app/upgrades/v0.1.5-test/send_coin.go
+++ b/app/upgrades/v0.1.5-test/send_coin.go
@@ -12,13 +12,15 @@ func upgradeSendCoin(
 	ctx sdk.Context,
 	bankkeeper bankkeeper.Keeper,
 ) error {
-	fromAddress := "sunrise155u042u8wk3al32h3vzxu989jj76k4zcc6d03n"
+	fromAddress := "sunrise1kw8x5dncdw7ualrx02q4cldcxhsmg5vwtxaxvq"
 	toAddresses := []string{
+		// new validators
 		"sunrise1m63dprapnud2sy3npvw5mgh4nw606u7x5krrhw",
 		"sunrise18w30e2qvexwmge4mct99n7mmreczv8sacr322z",
 		"sunrise1kw8x5dncdw7ualrx02q4cldcxhsmg5vwtxaxvq",
 	}
-	coin := sdk.NewInt64Coin("uvrise", 1000)
+	// same amount as older validator's one
+	coin := sdk.NewInt64Coin("uvrise", 9000000000000)
 
 	fromAddr, err := sdk.AccAddressFromBech32(fromAddress)
 	if err != nil {

--- a/app/upgrades/v0.1.5-test/send_coin.go
+++ b/app/upgrades/v0.1.5-test/send_coin.go
@@ -1,0 +1,41 @@
+package v0_1_5_test
+
+import (
+	"fmt"
+	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+)
+
+func upgradeSendCoin(
+	ctx sdk.Context,
+	bankkeeper bankkeeper.Keeper,
+) error {
+	fromAddress := "sunrise155u042u8wk3al32h3vzxu989jj76k4zcc6d03n"
+	toAddresses := []string{
+		"sunrise1m63dprapnud2sy3npvw5mgh4nw606u7x5krrhw",
+		"sunrise18w30e2qvexwmge4mct99n7mmreczv8sacr322z",
+		"sunrise1kw8x5dncdw7ualrx02q4cldcxhsmg5vwtxaxvq",
+	}
+	coin := sdk.NewInt64Coin("uvrise", 1000)
+
+	fromAddr, err := sdk.AccAddressFromBech32(fromAddress)
+	if err != nil {
+		panic(err)
+	}
+
+	for index, toAddress := range toAddresses {
+		toAddr, err := sdk.AccAddressFromBech32(toAddress)
+		if err != nil {
+			panic(err)
+		}
+		// if the account is not existent, this method creates account internally
+		if err := bankkeeper.SendCoins(ctx, fromAddr, toAddr, sdk.NewCoins(coin)); err != nil {
+			panic(err)
+		}
+		ctx.Logger().Info(fmt.Sprintf("send coin [%s] : target [%s]", strconv.Itoa(index), toAddress))
+
+	}
+	return nil
+}

--- a/app/upgrades/v0.1.5-test/upgrades.go
+++ b/app/upgrades/v0.1.5-test/upgrades.go
@@ -9,13 +9,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	"github.com/sunriselayer/sunrise/app/keepers"
-	"github.com/sunriselayer/sunrise/app/upgrades"
 )
 
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
-	_ upgrades.BaseAppParamManager,
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(context context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {

--- a/app/upgrades/v0.1.5-test/upgrades.go
+++ b/app/upgrades/v0.1.5-test/upgrades.go
@@ -7,7 +7,7 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-
+	"github.com/cosmos/ibc-go/modules/capability"
 	"github.com/sunriselayer/sunrise/app/keepers"
 )
 
@@ -24,6 +24,8 @@ func CreateUpgradeHandler(
 		if err != nil {
 			panic(err)
 		}
+		// To skip running foo's InitGenesis, you need set `fromVM`'s foo to its latest consensus version:
+		vm["capability"] = capability.AppModule{}.ConsensusVersion()
 
 		return mm.RunMigrations(ctx, configurator, vm)
 	}

--- a/app/upgrades/v0.1.5-test/upgrades.go
+++ b/app/upgrades/v0.1.5-test/upgrades.go
@@ -7,8 +7,8 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/sunriselayer/sunrise/app"
 
+	"github.com/sunriselayer/sunrise/app/keepers"
 	"github.com/sunriselayer/sunrise/app/upgrades"
 )
 
@@ -16,13 +16,13 @@ func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
 	_ upgrades.BaseAppParamManager,
-	app *app.App,
+	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(context context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(context)
 		ctx.Logger().Info(fmt.Sprintf("update start:%s", UpgradeName))
 
-		err := upgradeSendCoin(ctx, app.BankKeeper)
+		err := upgradeSendCoin(ctx, keepers.BankKeeper)
 		if err != nil {
 			panic(err)
 		}

--- a/app/upgrades/v0.1.5-test/upgrades.go
+++ b/app/upgrades/v0.1.5-test/upgrades.go
@@ -1,0 +1,32 @@
+package v0_1_5_test
+
+import (
+	context "context"
+	"fmt"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/sunriselayer/sunrise/app"
+
+	"github.com/sunriselayer/sunrise/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	_ upgrades.BaseAppParamManager,
+	app *app.App,
+) upgradetypes.UpgradeHandler {
+	return func(context context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(context)
+		ctx.Logger().Info(fmt.Sprintf("update start:%s", UpgradeName))
+
+		err := upgradeSendCoin(ctx, app.BankKeeper)
+		if err != nil {
+			panic(err)
+		}
+
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

- Add Upgrade Handler & Upgrade Store Loader in `app.go`
- Separate `keeper.go` to solve import cycle problem
- Add Upgrade handler `v0.1.5-test`

TODO
- [x] test in private-testnet 
- [ ] Add validators address
- [ ] create binary
- [ ] submit upgrade-proposal 

## Note

It would be a problem with capability module init genesis codebase itself.
`panic: SetIndex requires index to not be set`
Skip `capability` db InitGenesis() in upgrade to avoid this problem. https://github.com/sunriselayer/sunrise/pull/110/commits/a3b520e55744bef27112c3cbe711b99802bab865
issue: https://github.com/cosmos/cosmos-sdk/issues/8503

This solution does not work for on-chain upgrade. 
https://github.com/BlitChain/blitchain/commit/c4c5f265703e72d38fc31d0084df11db60773600#diff-ef25d41c9af76a92d23ba24961af4a2870d6799c9695f9c3f51074be42ca022eR25
An error in IBC (channel open)
```
gRPC call `send_tx_simulate` failed with status: status: Unknown, message: "recovered: kv store with key KVStoreKey{0xc001a7d2a0, capability} has not been registered in stores
```

Capability module use to be available from long ago but the code seems moved from one repo to another. (cosmos-sdk to ibc-go)
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
