### PR TITLE
fix: unused DeletePosition comment-out

### DIFF
--- a/x/liquiditypool/keeper/accumulator.go
+++ b/x/liquiditypool/keeper/accumulator.go
@@ -247,37 +247,37 @@ func (k Keeper) SetPositionIntervalAccumulation(ctx context.Context, accumName, 
 	return nil
 }
 
-func (k Keeper) DeletePosition(ctx context.Context, accumName, positionName string) (sdk.DecCoins, error) {
-	position, err := k.GetAccumulatorPosition(ctx, accumName, positionName)
-	if err != nil {
-		return sdk.DecCoins{}, err
-	}
+// func (k Keeper) LiquidateAndDeletePosition(ctx context.Context, accumName, positionName string) (sdk.DecCoins, error) {
+// 	position, err := k.GetAccumulatorPosition(ctx, accumName, positionName)
+// 	if err != nil {
+// 		return sdk.DecCoins{}, err
+// 	}
 
-	remainingRewards, dust, err := k.ClaimRewards(ctx, accumName, positionName)
-	if err != nil {
-		return sdk.DecCoins{}, err
-	}
+// 	remainingRewards, dust, err := k.ClaimRewards(ctx, accumName, positionName)
+// 	if err != nil {
+// 		return sdk.DecCoins{}, err
+// 	}
 
-	store := k.storeService.OpenKVStore(ctx)
-	err = store.Delete(types.FormatKeyAccumulatorPositionPrefix(accumName, positionName))
-	if err != nil {
-		return sdk.DecCoins{}, err
-	}
+// 	store := k.storeService.OpenKVStore(ctx)
+// 	err = store.Delete(types.FormatKeyAccumulatorPositionPrefix(accumName, positionName))
+// 	if err != nil {
+// 		return sdk.DecCoins{}, err
+// 	}
 
-	accumulator, err := k.GetAccumulator(ctx, accumName)
-	if err != nil {
-		return sdk.DecCoins{}, err
-	}
-	accumulator.TotalShares.SubMut(position.NumShares)
-	err = k.SetAccumulator(ctx, accumulator)
-	if err != nil {
-		return sdk.DecCoins{}, err
-	}
+// 	accumulator, err := k.GetAccumulator(ctx, accumName)
+// 	if err != nil {
+// 		return sdk.DecCoins{}, err
+// 	}
+// 	accumulator.TotalShares.SubMut(position.NumShares)
+// 	err = k.SetAccumulator(ctx, accumulator)
+// 	if err != nil {
+// 		return sdk.DecCoins{}, err
+// 	}
 
-	return sdk.NewDecCoinsFromCoins(remainingRewards...).Add(dust...), nil
-}
+// 	return sdk.NewDecCoinsFromCoins(remainingRewards...).Add(dust...), nil
+// }
 
-func (k Keeper) deletePosition(ctx context.Context, accumName, positionName string) {
+func (k Keeper) DeletePosition(ctx context.Context, accumName, positionName string) {
 	store := k.storeService.OpenKVStore(ctx)
 	err := store.Delete(types.FormatKeyAccumulatorPositionPrefix(accumName, positionName))
 	if err != nil {
@@ -318,7 +318,7 @@ func (k Keeper) ClaimRewards(ctx context.Context, accumName, positionName string
 	truncatedRewardsTotal, dust := totalRewards.TruncateDecimal()
 
 	if position.NumShares.IsZero() {
-		k.deletePosition(ctx, accumName, positionName)
+		k.DeletePosition(ctx, accumName, positionName)
 	} else {
 		k.SetAccumulatorPosition(ctx, accumName, accumulator.AccumValue, positionName, position.NumShares, sdk.NewDecCoins())
 	}

--- a/x/liquiditypool/keeper/accumulator_test.go
+++ b/x/liquiditypool/keeper/accumulator_test.go
@@ -275,7 +275,7 @@ func TestGetTotalRewards(t *testing.T) {
 	require.Equal(t, rewards.String(), "")
 }
 
-// func TestDeletePosition(t *testing.T) {
+// func TestLiquidateAndDeletePosition(t *testing.T) {
 // 	k, _, ctx := keepertest.LiquiditypoolKeeper(t)
 // 	// when position does not exist
 // 	accmulatorValuePerShare := sdk.NewDecCoins(sdk.NewDecCoin("denom", math.NewInt(1)))

--- a/x/liquiditypool/keeper/accumulator_test.go
+++ b/x/liquiditypool/keeper/accumulator_test.go
@@ -275,40 +275,40 @@ func TestGetTotalRewards(t *testing.T) {
 	require.Equal(t, rewards.String(), "")
 }
 
-func TestDeletePosition(t *testing.T) {
-	k, _, ctx := keepertest.LiquiditypoolKeeper(t)
-	// when position does not exist
-	accmulatorValuePerShare := sdk.NewDecCoins(sdk.NewDecCoin("denom", math.NewInt(1)))
-	_, err := k.DeletePosition(ctx, "accumulator", "index")
-	require.Error(t, err)
+// func TestDeletePosition(t *testing.T) {
+// 	k, _, ctx := keepertest.LiquiditypoolKeeper(t)
+// 	// when position does not exist
+// 	accmulatorValuePerShare := sdk.NewDecCoins(sdk.NewDecCoin("denom", math.NewInt(1)))
+// 	_, err := k.LiquidateAndDeletePosition(ctx, "accumulator", "index")
+// 	require.Error(t, err)
 
-	// when accumulator and position exists
-	err = k.InitAccumulator(ctx, "accumulator")
-	require.NoError(t, err)
+// 	// when accumulator and position exists
+// 	err = k.InitAccumulator(ctx, "accumulator")
+// 	require.NoError(t, err)
 
-	accumulator, err := k.GetAccumulator(ctx, "accumulator")
-	require.NoError(t, err)
-	accumulator.AccumValue = accumulator.AccumValue.Add(accmulatorValuePerShare...).Add(accmulatorValuePerShare...)
-	err = k.SetAccumulator(ctx, accumulator)
-	require.NoError(t, err)
+// 	accumulator, err := k.GetAccumulator(ctx, "accumulator")
+// 	require.NoError(t, err)
+// 	accumulator.AccumValue = accumulator.AccumValue.Add(accmulatorValuePerShare...).Add(accmulatorValuePerShare...)
+// 	err = k.SetAccumulator(ctx, accumulator)
+// 	require.NoError(t, err)
 
-	err = k.NewPositionIntervalAccumulation(ctx, "accumulator", "index", math.LegacyOneDec(), accmulatorValuePerShare)
-	require.NoError(t, err)
-	rewards, err := k.DeletePosition(ctx, "accumulator", "index")
-	require.NoError(t, err)
-	require.Equal(t, rewards.String(), "1.000000000000000000denom")
+// 	err = k.NewPositionIntervalAccumulation(ctx, "accumulator", "index", math.LegacyOneDec(), accmulatorValuePerShare)
+// 	require.NoError(t, err)
+// 	rewards, err := k.LiquidateAndDeletePosition(ctx, "accumulator", "index")
+// 	require.NoError(t, err)
+// 	require.Equal(t, rewards.String(), "1.000000000000000000denom")
 
-	// check accumulator change
-	accumulator, err = k.GetAccumulator(ctx, "accumulator")
-	require.NoError(t, err)
-	require.Equal(t, accumulator.Name, "accumulator")
-	require.Equal(t, accumulator.AccumValue.String(), "2.000000000000000000denom")
-	require.Equal(t, accumulator.TotalShares.String(), "0.000000000000000000")
+// 	// check accumulator change
+// 	accumulator, err = k.GetAccumulator(ctx, "accumulator")
+// 	require.NoError(t, err)
+// 	require.Equal(t, accumulator.Name, "accumulator")
+// 	require.Equal(t, accumulator.AccumValue.String(), "2.000000000000000000denom")
+// 	require.Equal(t, accumulator.TotalShares.String(), "0.000000000000000000")
 
-	// check accumulator position change
-	_, err = k.GetAccumulatorPosition(ctx, "accumulator", "index")
-	require.Error(t, err)
-}
+// 	// check accumulator position change
+// 	_, err = k.GetAccumulatorPosition(ctx, "accumulator", "index")
+// 	require.Error(t, err)
+// }
 
 func TestClaimRewards(t *testing.T) {
 	k, _, ctx := keepertest.LiquiditypoolKeeper(t)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

There were `DeletePosition` & `deletePosition`

- `DeletePosition` is not used, so it and its test are comment out (change function name LiquidateAndDeletePosition)
- `deletePosition` => `DeletePosition` 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
