### PR TITLE
Fix: Synchronize position deletion in PositionsByPoolId

### DIFF
--- a/x/liquiditypool/keeper/store_position.go
+++ b/x/liquiditypool/keeper/store_position.go
@@ -85,6 +85,14 @@ func (k Keeper) RemovePosition(ctx context.Context, id uint64) {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.PositionKey))
 	store.Delete(GetPositionIDBytes(id))
+
+	// Remove from PositionsByPoolId
+	position, found := k.GetPosition(ctx, id)
+	if found {
+		positionKey := sdk.Uint64ToBigEndian(id)
+		poolStore := prefix.NewStore(storeAdapter, types.PositionByPoolPrefix(position.PoolId))
+		poolStore.Delete(positionKey)
+	}
 }
 
 // GetAllPositions returns all position

--- a/x/liquiditypool/keeper/store_position.go
+++ b/x/liquiditypool/keeper/store_position.go
@@ -86,12 +86,11 @@ func (k Keeper) RemovePosition(ctx context.Context, id uint64) {
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.PositionKey))
 	store.Delete(GetPositionIDBytes(id))
 
-	// Remove from PositionsByPoolId
+	// Retrieve the position to get the address
 	position, found := k.GetPosition(ctx, id)
 	if found {
-		positionKey := sdk.Uint64ToBigEndian(id)
-		poolStore := prefix.NewStore(storeAdapter, types.PositionByPoolPrefix(position.PoolId))
-		poolStore.Delete(positionKey)
+		k.RemovePositionsByPool(ctx, position.PoolId)
+		k.RemovePositionsByAddress(ctx, position.Address)
 	}
 }
 
@@ -167,4 +166,30 @@ func (k Keeper) GetPositionsByAddress(ctx context.Context, addr string) []types.
 		}
 	}
 	return positions
+}
+
+// RemovePositionsByPool removes all positions associated with the given pool ID
+func (k Keeper) RemovePositionsByPool(ctx context.Context, poolId uint64) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.PositionByPoolPrefix(poolId))
+	iterator := storetypes.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		id := sdk.BigEndianToUint64(iterator.Value())
+		store.Delete(GetPositionIDBytes(id))
+	}
+}
+
+// RemovePositionsByAddress removes all positions associated with the given address
+func (k Keeper) RemovePositionsByAddress(ctx context.Context, address string) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.PositionByAddressPrefix(address))
+	iterator := storetypes.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		id := sdk.BigEndianToUint64(iterator.Value())
+		store.Delete(GetPositionIDBytes(id))
+	}
 }


### PR DESCRIPTION
## Overview

fix #143
This PR addresses an issue where the `Delete` method did not synchronize the deleted position in the `PositionsByPoolId` store. 

### Changes Made:
- Updated the `RemovePosition` method in the `store_position.go` file to ensure that when a position is deleted from the main store, it is also removed from the corresponding `PositionsByPoolId` store.
- Added logic to retrieve the `PoolId` of the deleted position and delete the position from the pool-specific store.

### Impact:
This change ensures that the state of the positions is consistent across all relevant stores, preventing potential issues with data integrity when querying positions by pool ID after deletions.
