### PR TITLE
fix: store panic

### DIFF
--- a/x/da/keeper/abci.go
+++ b/x/da/keeper/abci.go
@@ -283,7 +283,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 	}
 	for _, data := range rejectedData {
 		if data.Status == types.Status_STATUS_REJECTED {
-			k.DeletePublishedData(sdkCtx, data)
+			err = k.DeletePublishedData(sdkCtx, data)
+			if err != nil {
+				k.Logger.Error(err.Error())
+				continue
+			}
 		}
 	}
 
@@ -296,7 +300,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 		}
 		for _, data := range verifiedData {
 			if data.Status == types.Status_STATUS_VERIFIED {
-				k.DeletePublishedData(sdkCtx, data)
+				err = k.DeletePublishedData(sdkCtx, data)
+				if err != nil {
+					k.Logger.Error(err.Error())
+					continue
+				}
 			}
 		}
 	}

--- a/x/da/keeper/abci.go
+++ b/x/da/keeper/abci.go
@@ -240,9 +240,22 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 			}
 
 			// Count challenge & fault validators
-			k.SetChallengeCounter(ctx, k.GetChallengeCounter(ctx)+1)
+			err = k.SetChallengeCounter(ctx, k.GetChallengeCounter(ctx)+1)
+			if err != nil {
+				k.Logger.Error(err.Error())
+				return
+			}
 			for _, valAddr := range faultValidators {
-				k.SetFaultCounter(ctx, valAddr, k.GetFaultCounter(ctx, valAddr)+1)
+				count, err := k.GetFaultCounter(ctx, valAddr)
+				if err != nil {
+					k.Logger.Error(err.Error())
+					continue
+				}
+				err = k.SetFaultCounter(ctx, valAddr, count+1)
+				if err != nil {
+					k.Logger.Error(err.Error())
+					continue
+				}
 			}
 
 			// Clean up proofs data

--- a/x/da/keeper/abci.go
+++ b/x/da/keeper/abci.go
@@ -83,9 +83,6 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 	}
 
 	activeValidators := []sdk.ValAddress{}
-	// numActiveValidators := int64(0)
-	// votingPowers := make(map[string]int64)
-	// powerReduction := k.StakingKeeper.PowerReduction(ctx)
 	iterator, err := k.StakingKeeper.ValidatorsPowerStoreIterator(ctx)
 	if err != nil {
 		k.Logger.Error(err.Error())
@@ -99,18 +96,8 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 			k.Logger.Error(err.Error())
 			return
 		}
-
 		if validator.IsBonded() {
 			activeValidators = append(activeValidators, sdk.ValAddress(iterator.Value()))
-			// valAddrStr := validator.GetOperator()
-			// valAddr, err := sdk.ValAddressFromBech32(valAddrStr)
-			// if err != nil {
-			// 	k.Logger().Error(err.Error())
-			// 	return
-			// }
-
-			// votingPowers[sdk.AccAddress(valAddr).String()] = validator.GetConsensusPower(powerReduction)
-			// numActiveValidators++
 		}
 	}
 
@@ -119,14 +106,6 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 
 	for _, data := range challengingData {
 		if data.Status == types.Status_STATUS_CHALLENGING {
-			// bondedTokens, err := k.StakingKeeper.TotalBondedTokens(ctx)
-			// if err != nil {
-			// 	k.Logger().Error(err.Error())
-			// 	return
-			// }
-
-			// totalBondedPower := sdk.TokensToConsensusPower(bondedTokens, k.StakingKeeper.PowerReduction(ctx))
-			// thresholdPower := params.VoteThreshold.MulInt64(totalBondedPower).RoundInt().Int64()
 			proofs, err := k.GetProofs(sdkCtx, data.MetadataUri)
 			if err != nil {
 				k.Logger.Error(err.Error())

--- a/x/da/keeper/abci.go
+++ b/x/da/keeper/abci.go
@@ -127,7 +127,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 
 			// totalBondedPower := sdk.TokensToConsensusPower(bondedTokens, k.StakingKeeper.PowerReduction(ctx))
 			// thresholdPower := params.VoteThreshold.MulInt64(totalBondedPower).RoundInt().Int64()
-			proofs := k.GetProofs(sdkCtx, data.MetadataUri)
+			proofs, err := k.GetProofs(sdkCtx, data.MetadataUri)
+			if err != nil {
+				k.Logger.Error(err.Error())
+				continue
+			}
 			shardProofCount := make(map[int64]int64)
 			shardProofSubmitted := make(map[int64]map[string]bool)
 			for _, proof := range proofs {
@@ -248,7 +252,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 					k.Logger.Error(err.Error())
 					continue
 				}
-				k.DeleteProof(sdkCtx, proof.MetadataUri, addr)
+				err = k.DeleteProof(sdkCtx, proof.MetadataUri, addr)
+				if err != nil {
+					k.Logger.Error(err.Error())
+					continue
+				}
 			}
 
 			// Clean up invalidity data

--- a/x/da/keeper/abci.go
+++ b/x/da/keeper/abci.go
@@ -23,7 +23,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 	}
 	for _, data := range challengePeriodData {
 		if data.Status == types.Status_STATUS_CHALLENGE_PERIOD {
-			invalidities := k.GetInvalidities(sdkCtx, data.MetadataUri)
+			invalidities, err := k.GetInvalidities(sdkCtx, data.MetadataUri)
+			if err != nil {
+				k.Logger.Error("failed to get invalidities", "error", err)
+				continue
+			}
 			seen := make(map[int64]bool)
 			invalidIndices := []int64{}
 			for _, invalidity := range invalidities {
@@ -168,7 +172,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 			}
 
 			// valid_shards < data_shard_count
-			invalidities := k.GetInvalidities(sdkCtx, data.MetadataUri)
+			invalidities, err := k.GetInvalidities(sdkCtx, data.MetadataUri)
+			if err != nil {
+				k.Logger.Error("failed to get invalidities", "error", err)
+				continue
+			}
 			if int64(len(safeShardIndices))+int64(data.ParityShardCount) < int64(len(data.ShardDoubleHashes)) {
 				data.Status = types.Status_STATUS_REJECTED
 				err = k.SetPublishedData(ctx, data)
@@ -250,7 +258,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 					k.Logger.Error(err.Error())
 					continue
 				}
-				k.DeleteInvalidity(sdkCtx, invalidity.MetadataUri, addr)
+				err = k.DeleteInvalidity(sdkCtx, invalidity.MetadataUri, addr)
+				if err != nil {
+					k.Logger.Error(err.Error())
+					continue
+				}
 			}
 		}
 	}

--- a/x/da/keeper/abci.go
+++ b/x/da/keeper/abci.go
@@ -141,7 +141,11 @@ func (k Keeper) EndBlocker(ctx context.Context) {
 				}
 			}
 
-			threshold := k.GetZkpThreshold(ctx, uint64(len(data.ShardDoubleHashes)))
+			threshold, err := k.GetZkpThreshold(ctx, uint64(len(data.ShardDoubleHashes)))
+			if err != nil {
+				k.Logger.Error(err.Error())
+				continue
+			}
 			indexedValidators := make(map[int64][]sdk.ValAddress)
 			for _, valAddr := range activeValidators {
 				indices := types.ShardIndicesForValidator(valAddr, int64(threshold), int64(len(data.ShardDoubleHashes)))

--- a/x/da/keeper/genesis.go
+++ b/x/da/keeper/genesis.go
@@ -33,7 +33,10 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 	}
 
 	genesis.PublishedData = k.GetAllPublishedData(ctx)
-	genesis.Proofs = k.GetAllProofs(ctx)
+	genesis.Proofs, err = k.GetAllProofs(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return genesis, nil
 }

--- a/x/da/keeper/genesis.go
+++ b/x/da/keeper/genesis.go
@@ -32,7 +32,10 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 		return nil, err
 	}
 
-	genesis.PublishedData = k.GetAllPublishedData(ctx)
+	genesis.PublishedData, err = k.GetAllPublishedData(ctx)
+	if err != nil {
+		return nil, err
+	}
 	genesis.Proofs, err = k.GetAllProofs(ctx)
 	if err != nil {
 		return nil, err

--- a/x/da/keeper/keeper_threshold.go
+++ b/x/da/keeper/keeper_threshold.go
@@ -30,7 +30,7 @@ func (k Keeper) GetZkpThreshold(ctx context.Context, shardCount uint64) (uint64,
 		return 0, err
 	}
 	replicationFactor := math.LegacyMustNewDecFromStr(params.ReplicationFactor) // TODO: remove with Dec
-	threshold := min(max(replicationFactor.MulInt64(int64(shardCount)).QuoInt64(int64(numActiveValidators)).RoundInt64(), 1), int64(shardCount))
+	threshold := min(max(replicationFactor.MulInt64(int64(shardCount)).QuoInt64(int64(numActiveValidators)).TruncateInt64(), 1), int64(shardCount))
 
 	return uint64(threshold), nil
 }

--- a/x/da/keeper/keeper_threshold.go
+++ b/x/da/keeper/keeper_threshold.go
@@ -6,31 +6,31 @@ import (
 	"cosmossdk.io/math"
 )
 
-func (k Keeper) GetZkpThreshold(ctx context.Context, shardCount uint64) uint64 {
+func (k Keeper) GetZkpThreshold(ctx context.Context, shardCount uint64) (uint64, error) {
 	numActiveValidators := int64(0)
 	iterator, err := k.StakingKeeper.ValidatorsPowerStoreIterator(ctx)
 	if err != nil {
-		k.Logger.Error(err.Error())
-		return 0
+		return 0, err
 	}
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		numActiveValidators++
+		validator, err := k.StakingKeeper.Validator(ctx, iterator.Value())
+		if err != nil {
+			k.Logger.Error(err.Error())
+			continue
+		}
+		if validator.IsBonded() {
+			numActiveValidators++
+		}
 	}
 
-	// TODO: error handling
-	params, _ := k.Params.Get(ctx)
+	params, err := k.Params.Get(ctx)
+	if err != nil {
+		return 0, err
+	}
 	replicationFactor := math.LegacyMustNewDecFromStr(params.ReplicationFactor) // TODO: remove with Dec
-	threshold := replicationFactor.MulInt64(int64(shardCount)).QuoInt64(int64(numActiveValidators)).RoundInt64()
+	threshold := min(max(replicationFactor.MulInt64(int64(shardCount)).QuoInt64(int64(numActiveValidators)).RoundInt64(), 1), int64(shardCount))
 
-	if threshold < 1 {
-		threshold = 1
-	}
-
-	if threshold > int64(shardCount) {
-		threshold = int64(shardCount)
-	}
-
-	return uint64(threshold)
+	return uint64(threshold), nil
 }

--- a/x/da/keeper/msg_server_proof_deputy.go
+++ b/x/da/keeper/msg_server_proof_deputy.go
@@ -36,12 +36,18 @@ func (k msgServer) UnregisterProofDeputy(ctx context.Context, msg *types.MsgUnre
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid sender address")
 	}
-	_, found := k.GetProofDeputy(ctx, sender)
+	_, found, err := k.GetProofDeputy(ctx, sender)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to get proof deputy")
+	}
 	if !found {
 		return nil, types.ErrDeputyNotFound
 	}
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	k.DeleteProofDeputy(sdkCtx, sender)
+	err = k.DeleteProofDeputy(sdkCtx, sender)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to delete proof deputy")
+	}
 
 	err = sdkCtx.EventManager().EmitTypedEvent(msg)
 	if err != nil {

--- a/x/da/keeper/msg_server_submit_invalidity.go
+++ b/x/da/keeper/msg_server_submit_invalidity.go
@@ -22,7 +22,10 @@ func (k msgServer) SubmitInvalidity(ctx context.Context, msg *types.MsgSubmitInv
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	publishedData, found := k.GetPublishedData(ctx, msg.MetadataUri)
+	publishedData, found, err := k.GetPublishedData(ctx, msg.MetadataUri)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, types.ErrDataNotFound
 	}

--- a/x/da/keeper/msg_server_submit_validity_proof.go
+++ b/x/da/keeper/msg_server_submit_validity_proof.go
@@ -29,10 +29,13 @@ func (k msgServer) SubmitValidityProof(ctx context.Context, msg *types.MsgSubmit
 	valAddr := sdk.ValAddress(validator)
 	_, err = k.StakingKeeper.Validator(ctx, valAddr)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "validator not exists")
 	}
 	if !bytes.Equal(sender, validator) {
-		deputy, found := k.GetProofDeputy(ctx, validator)
+		deputy, found, err := k.GetProofDeputy(ctx, validator)
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "failed to get proof deputy")
+		}
 		if !found {
 			return nil, types.ErrDeputyNotFound
 		}

--- a/x/da/keeper/msg_server_submit_validity_proof.go
+++ b/x/da/keeper/msg_server_submit_validity_proof.go
@@ -52,7 +52,10 @@ func (k msgServer) SubmitValidityProof(ctx context.Context, msg *types.MsgSubmit
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	publishedData, found := k.GetPublishedData(ctx, msg.MetadataUri)
+	publishedData, found, err := k.GetPublishedData(ctx, msg.MetadataUri)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, types.ErrDataNotFound
 	}

--- a/x/da/keeper/query_da.go
+++ b/x/da/keeper/query_da.go
@@ -16,7 +16,10 @@ func (q queryServer) PublishedData(goCtx context.Context, req *types.QueryPublis
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	data, found := q.k.GetPublishedData(ctx, req.MetadataUri)
+	data, found, err := q.k.GetPublishedData(ctx, req.MetadataUri)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, types.ErrDataNotFound
 	}
@@ -29,7 +32,11 @@ func (q queryServer) AllPublishedData(goCtx context.Context, req *types.QueryAll
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryAllPublishedDataResponse{Data: q.k.GetAllPublishedData(ctx)}, nil
+	data, err := q.k.GetAllPublishedData(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &types.QueryAllPublishedDataResponse{Data: data}, nil
 }
 
 func (q queryServer) ZkpProofThreshold(goCtx context.Context, req *types.QueryZkpProofThresholdRequest) (*types.QueryZkpProofThresholdResponse, error) {

--- a/x/da/keeper/query_da.go
+++ b/x/da/keeper/query_da.go
@@ -51,7 +51,10 @@ func (q queryServer) ProofDeputy(goCtx context.Context, req *types.QueryProofDep
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid validator address")
 	}
-	deputy, found := q.k.GetProofDeputy(ctx, validator)
+	deputy, found, err := q.k.GetProofDeputy(ctx, validator)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, types.ErrDeputyNotFound
 	}

--- a/x/da/keeper/query_da.go
+++ b/x/da/keeper/query_da.go
@@ -99,7 +99,10 @@ func (q queryServer) Invalidity(goCtx context.Context, req *types.QueryInvalidit
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid sender address")
 	}
-	invalidity, found := q.k.GetInvalidity(ctx, req.MetadataUri, sender)
+	invalidity, found, err := q.k.GetInvalidity(ctx, req.MetadataUri, sender)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, types.ErrProofNotFound
 	}
@@ -113,5 +116,10 @@ func (q queryServer) AllInvalidity(goCtx context.Context, req *types.QueryAllInv
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryAllInvalidityResponse{Invalidity: q.k.GetAllInvalidities(ctx)}, nil
+	invalidities, err := q.k.GetAllInvalidities(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.QueryAllInvalidityResponse{Invalidity: invalidities}, nil
 }

--- a/x/da/keeper/query_da.go
+++ b/x/da/keeper/query_da.go
@@ -72,7 +72,10 @@ func (q queryServer) ValidityProof(goCtx context.Context, req *types.QueryValidi
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid validator address")
 	}
-	proof, found := q.k.GetProof(ctx, req.MetadataUri, validator)
+	proof, found, err := q.k.GetProof(ctx, req.MetadataUri, validator)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, types.ErrProofNotFound
 	}
@@ -86,7 +89,11 @@ func (q queryServer) AllValidityProofs(goCtx context.Context, req *types.QueryAl
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryAllValidityProofsResponse{Proofs: q.k.GetAllProofs(ctx)}, nil
+	proofs, err := q.k.GetAllProofs(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &types.QueryAllValidityProofsResponse{Proofs: proofs}, nil
 }
 
 func (q queryServer) Invalidity(goCtx context.Context, req *types.QueryInvalidityRequest) (*types.QueryInvalidityResponse, error) {

--- a/x/da/keeper/query_da.go
+++ b/x/da/keeper/query_da.go
@@ -45,7 +45,11 @@ func (q queryServer) ZkpProofThreshold(goCtx context.Context, req *types.QueryZk
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryZkpProofThresholdResponse{Threshold: q.k.GetZkpThreshold(ctx, req.ShardCount)}, nil
+	threshold, err := q.k.GetZkpThreshold(ctx, req.ShardCount)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &types.QueryZkpProofThresholdResponse{Threshold: threshold}, nil
 }
 
 func (q queryServer) ProofDeputy(goCtx context.Context, req *types.QueryProofDeputyRequest) (*types.QueryProofDeputyResponse, error) {

--- a/x/da/keeper/store_deputy.go
+++ b/x/da/keeper/store_deputy.go
@@ -2,26 +2,24 @@ package keeper
 
 import (
 	"context"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (k Keeper) GetProofDeputy(ctx context.Context, validator []byte) (deputy []byte, found bool) {
+func (k Keeper) GetProofDeputy(ctx context.Context, validator []byte) (deputy []byte, found bool, err error) {
 	has, err := k.ProofDeputies.Has(ctx, validator)
 	if err != nil {
-		panic(err)
+		return deputy, false, err
 	}
 
 	if !has {
-		return deputy, false
+		return deputy, false, nil
 	}
 
 	deputy, err = k.ProofDeputies.Get(ctx, validator)
 	if err != nil {
-		panic(err)
+		return deputy, false, err
 	}
 
-	return deputy, true
+	return deputy, true, nil
 }
 
 // SetProofDeputy set the proof deputy of the validator
@@ -34,9 +32,11 @@ func (k Keeper) SetProofDeputy(ctx context.Context, validator []byte, deputy []b
 	return nil
 }
 
-func (k Keeper) DeleteProofDeputy(ctx sdk.Context, validator []byte) {
+func (k Keeper) DeleteProofDeputy(ctx context.Context, validator []byte) error {
 	err := k.ProofDeputies.Remove(ctx, validator)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }

--- a/x/da/keeper/store_invalidity.go
+++ b/x/da/keeper/store_invalidity.go
@@ -9,23 +9,23 @@ import (
 	"github.com/sunriselayer/sunrise/x/da/types"
 )
 
-func (k Keeper) GetInvalidity(ctx context.Context, metadataUri string, sender []byte) (invalidity types.Invalidity, found bool) {
+func (k Keeper) GetInvalidity(ctx context.Context, metadataUri string, sender []byte) (invalidity types.Invalidity, found bool, err error) {
 	key := collections.Join(metadataUri, sender)
 	has, err := k.Invalidities.Has(ctx, key)
 	if err != nil {
-		panic(err)
+		return invalidity, false, err
 	}
 
 	if !has {
-		return invalidity, false
+		return invalidity, false, nil
 	}
 
 	val, err := k.Invalidities.Get(ctx, key)
 	if err != nil {
-		panic(err)
+		return invalidity, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // SetInvalidity set the Invalidity of the PublishedData
@@ -43,15 +43,17 @@ func (k Keeper) SetInvalidity(ctx context.Context, data types.Invalidity) error 
 	return nil
 }
 
-func (k Keeper) DeleteInvalidity(ctx sdk.Context, metadataUri string, sender []byte) {
+func (k Keeper) DeleteInvalidity(ctx context.Context, metadataUri string, sender []byte) error {
 	err := k.Invalidities.Remove(ctx, collections.Join(metadataUri, sender))
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
-func (k Keeper) GetInvalidities(ctx sdk.Context, metadataUri string) (list []types.Invalidity) {
-	err := k.Invalidities.Walk(
+func (k Keeper) GetInvalidities(ctx sdk.Context, metadataUri string) (list []types.Invalidity, err error) {
+	err = k.Invalidities.Walk(
 		ctx,
 		collections.NewPrefixedPairRange[string, []byte](metadataUri),
 		func(key collections.Pair[string, []byte], value types.Invalidity) (bool, error) {
@@ -60,14 +62,14 @@ func (k Keeper) GetInvalidities(ctx sdk.Context, metadataUri string) (list []typ
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }
 
-func (k Keeper) GetAllInvalidities(ctx context.Context) (list []types.Invalidity) {
-	err := k.Invalidities.Walk(
+func (k Keeper) GetAllInvalidities(ctx context.Context) (list []types.Invalidity, err error) {
+	err = k.Invalidities.Walk(
 		ctx,
 		nil,
 		func(key collections.Pair[string, []byte], value types.Invalidity) (bool, error) {
@@ -76,8 +78,8 @@ func (k Keeper) GetAllInvalidities(ctx context.Context) (list []types.Invalidity
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }

--- a/x/da/keeper/store_proof.go
+++ b/x/da/keeper/store_proof.go
@@ -9,23 +9,23 @@ import (
 	"github.com/sunriselayer/sunrise/x/da/types"
 )
 
-func (k Keeper) GetProof(ctx context.Context, metadataUri string, sender []byte) (proof types.Proof, found bool) {
+func (k Keeper) GetProof(ctx context.Context, metadataUri string, sender []byte) (proof types.Proof, found bool, err error) {
 	key := collections.Join(metadataUri, sender)
 	has, err := k.Proofs.Has(ctx, key)
 	if err != nil {
-		panic(err)
+		return proof, false, err
 	}
 
 	if !has {
-		return proof, false
+		return proof, false, nil
 	}
 
 	val, err := k.Proofs.Get(ctx, key)
 	if err != nil {
-		panic(err)
+		return proof, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // SetProof set the proof of the PublishedData
@@ -43,15 +43,17 @@ func (k Keeper) SetProof(ctx context.Context, data types.Proof) error {
 	return nil
 }
 
-func (k Keeper) DeleteProof(ctx sdk.Context, metadataUri string, sender []byte) {
+func (k Keeper) DeleteProof(ctx sdk.Context, metadataUri string, sender []byte) error {
 	err := k.Proofs.Remove(ctx, collections.Join(metadataUri, sender))
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
-func (k Keeper) GetProofs(ctx sdk.Context, metadataUri string) (list []types.Proof) {
-	err := k.Proofs.Walk(
+func (k Keeper) GetProofs(ctx sdk.Context, metadataUri string) (list []types.Proof, err error) {
+	err = k.Proofs.Walk(
 		ctx,
 		collections.NewPrefixedPairRange[string, []byte](metadataUri),
 		func(key collections.Pair[string, []byte], value types.Proof) (bool, error) {
@@ -60,14 +62,14 @@ func (k Keeper) GetProofs(ctx sdk.Context, metadataUri string) (list []types.Pro
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }
 
-func (k Keeper) GetAllProofs(ctx context.Context) (list []types.Proof) {
-	err := k.Proofs.Walk(
+func (k Keeper) GetAllProofs(ctx context.Context) (list []types.Proof, err error) {
+	err = k.Proofs.Walk(
 		ctx,
 		nil,
 		func(key collections.Pair[string, []byte], value types.Proof) (bool, error) {
@@ -76,8 +78,8 @@ func (k Keeper) GetAllProofs(ctx context.Context) (list []types.Proof) {
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }

--- a/x/da/keeper/store_published_data.go
+++ b/x/da/keeper/store_published_data.go
@@ -9,22 +9,22 @@ import (
 	"github.com/sunriselayer/sunrise/x/da/types"
 )
 
-func (k Keeper) GetPublishedData(ctx context.Context, metadataUri string) (data types.PublishedData, found bool) {
+func (k Keeper) GetPublishedData(ctx context.Context, metadataUri string) (data types.PublishedData, found bool, err error) {
 	has, err := k.PublishedData.Has(ctx, metadataUri)
 	if err != nil {
-		panic(err)
+		return data, false, err
 	}
 
 	if !has {
-		return data, false
+		return data, false, nil
 	}
 
 	val, err := k.PublishedData.Get(ctx, metadataUri)
 	if err != nil {
-		panic(err)
+		return data, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // SetParams set the params
@@ -37,15 +37,17 @@ func (k Keeper) SetPublishedData(ctx context.Context, data types.PublishedData) 
 	return nil
 }
 
-func (k Keeper) DeletePublishedData(ctx sdk.Context, data types.PublishedData) {
+func (k Keeper) DeletePublishedData(ctx sdk.Context, data types.PublishedData) error {
 	err := k.PublishedData.Remove(ctx, data.MetadataUri)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
-func (k Keeper) GetAllPublishedData(ctx context.Context) (list []types.PublishedData) {
-	err := k.PublishedData.Walk(
+func (k Keeper) GetAllPublishedData(ctx context.Context) (list []types.PublishedData, err error) {
+	err = k.PublishedData.Walk(
 		ctx,
 		nil,
 		func(key string, value types.PublishedData) (bool, error) {
@@ -54,10 +56,10 @@ func (k Keeper) GetAllPublishedData(ctx context.Context) (list []types.Published
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }
 
 func (k Keeper) GetSpecificStatusDataBeforeTime(ctx sdk.Context, status types.Status, timestamp int64) (list []types.PublishedData, err error) {
@@ -70,11 +72,17 @@ func (k Keeper) GetSpecificStatusDataBeforeTime(ctx sdk.Context, status types.St
 			if key.K2() > timestamp {
 				return true, nil
 			}
-			data,_ := k.PublishedData.Get(ctx, metadataUri)
+			data, err := k.PublishedData.Get(ctx, metadataUri)
+			if err != nil {
+				return false, err
+			}
 			list = append(list, data)
 			return false, nil
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 
-	return
+	return list, nil
 }

--- a/x/fee/ante/validator_tx_fee.go
+++ b/x/fee/ante/validator_tx_fee.go
@@ -62,7 +62,7 @@ func (dfd *DeductFeeDecorator) checkTxFeeWithValidatorMinGasPrices(ctx context.C
 			glDec := sdkmath.LegacyNewDec(int64(gas))
 			for i, gp := range minGasPrices {
 				fee := gp.Amount.Mul(glDec)
-				requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())
+				requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().TruncateInt())
 			}
 
 			if !feeCoins.IsAnyGTE(requiredFees) {

--- a/x/liquidityincentive/keeper/abci.go
+++ b/x/liquidityincentive/keeper/abci.go
@@ -52,7 +52,10 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) error {
 	vRise := k.bankKeeper.GetBalance(ctx, feeCollector, consts.BondDenom)
 	vRiseDec := sdk.NewDecCoinsFromCoins(vRise)
 
-	lastEpoch, found := k.GetLastEpoch(ctx)
+	lastEpoch, found, err := k.GetLastEpoch(ctx)
+	if err != nil {
+		return err
+	}
 	if !found {
 		return nil
 	}
@@ -89,7 +92,10 @@ func (k Keeper) EndBlocker(ctx sdk.Context) error {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, telemetry.Now(), telemetry.MetricKeyEndBlocker)
 
 	// Create a new `Epoch` if the last `Epoch` has ended or the first `Epoch` has not been created.
-	lastEpoch, found := k.GetLastEpoch(ctx)
+	lastEpoch, found, err := k.GetLastEpoch(ctx)
+	if err != nil {
+		return err
+	}
 	if !found {
 		err := k.CreateEpoch(ctx, 0, 1)
 		if err != nil {
@@ -103,7 +109,10 @@ func (k Keeper) EndBlocker(ctx sdk.Context) error {
 			return nil
 		}
 		// remove old epoch and gauges
-		epochs := k.GetAllEpoch(ctx)
+		epochs, err := k.GetAllEpoch(ctx)
+		if err != nil {
+			return err
+		}
 		if len(epochs) > 2 {
 			epoch := epochs[0]
 			k.RemoveEpoch(ctx, epoch.Id)

--- a/x/liquidityincentive/keeper/abci.go
+++ b/x/liquidityincentive/keeper/abci.go
@@ -26,7 +26,10 @@ func (k Keeper) CreateEpoch(ctx sdk.Context, previousEpochId, epochId uint64) er
 			PoolId:          result.PoolId,
 			Count:           result.Count,
 		}
-		k.SetGauge(ctx, gauge)
+		err := k.SetGauge(ctx, gauge)
+		if err != nil {
+			return err
+		}
 		gauges = append(gauges, gauge)
 	}
 
@@ -40,7 +43,10 @@ func (k Keeper) CreateEpoch(ctx sdk.Context, previousEpochId, epochId uint64) er
 		EndBlock:   ctx.BlockHeight() + params.EpochBlocks,
 		Gauges:     gauges,
 	}
-	k.SetEpoch(ctx, epoch)
+	err = k.SetEpoch(ctx, epoch)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -115,9 +121,15 @@ func (k Keeper) EndBlocker(ctx sdk.Context) error {
 		}
 		if len(epochs) > 2 {
 			epoch := epochs[0]
-			k.RemoveEpoch(ctx, epoch.Id)
+			err := k.RemoveEpoch(ctx, epoch.Id)
+			if err != nil {
+				return err
+			}
 			for _, gauge := range epoch.Gauges {
-				k.RemoveGauge(ctx, gauge.PreviousEpochId, gauge.PoolId)
+				err := k.RemoveGauge(ctx, gauge.PreviousEpochId, gauge.PoolId)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/x/liquidityincentive/keeper/abci_test.go
+++ b/x/liquidityincentive/keeper/abci_test.go
@@ -97,7 +97,8 @@ func TestCreateEpoch(t *testing.T) {
 				require.Equal(t, epochs[0].EndBlock, int64(5))
 				require.Len(t, epochs[0].Gauges, 1)
 
-				gauges := k.GetAllGauges(ctx)
+				gauges, err := k.GetAllGauges(ctx)
+				require.NoError(t, err)
 				require.Len(t, gauges, 1)
 				require.Equal(t, gauges[0].PreviousEpochId, uint64(0))
 				require.Equal(t, gauges[0].PoolId, tt.expectedTally[0].PoolId)
@@ -132,12 +133,13 @@ func TestEndBlocker(t *testing.T) {
 		{
 			name: "historical epochs",
 			setup: func(s tallyFixture) {
-				s.keeper.SetEpoch(s.ctx, types.Epoch{
+				err := s.keeper.SetEpoch(s.ctx, types.Epoch{
 					Id:         1,
 					StartBlock: 0,
 					EndBlock:   0,
 					Gauges:     []types.Gauge{},
 				})
+				require.NoError(t, err)
 				setTotalBonded(s, 10000000)
 				validatorVote(s, s.valAddrs[0], []types.PoolWeight{{PoolId: 1, Weight: "1"}})
 			},
@@ -205,7 +207,8 @@ func TestEndBlocker(t *testing.T) {
 				require.Equal(t, epoch.EndBlock, int64(5))
 				require.Len(t, epoch.Gauges, 1)
 
-				gauges := k.GetAllGauges(ctx)
+				gauges, err := k.GetAllGauges(ctx)
+				require.NoError(t, err)
 				require.Len(t, gauges, 1)
 				require.GreaterOrEqual(t, gauges[0].PreviousEpochId, uint64(0))
 				require.Equal(t, gauges[0].PoolId, tt.expectedTally[0].PoolId)
@@ -231,7 +234,7 @@ func TestBeginBlocker(t *testing.T) {
 		{
 			name: "existing epochs with positive fee collector balance",
 			setup: func(s tallyFixture) {
-				s.keeper.SetEpoch(s.ctx, types.Epoch{
+				err := s.keeper.SetEpoch(s.ctx, types.Epoch{
 					Id:         1,
 					StartBlock: 0,
 					EndBlock:   0,
@@ -243,7 +246,7 @@ func TestBeginBlocker(t *testing.T) {
 						},
 					},
 				})
-
+				require.NoError(t, err)
 				params, err := s.keeper.Params.Get(s.ctx)
 				require.NoError(t, err)
 				params.StakingRewardRatio = math.LegacyZeroDec().String()
@@ -258,7 +261,7 @@ func TestBeginBlocker(t *testing.T) {
 		{
 			name: "zero liquidity incentive allocation",
 			setup: func(s tallyFixture) {
-				s.keeper.SetEpoch(s.ctx, types.Epoch{
+				err := s.keeper.SetEpoch(s.ctx, types.Epoch{
 					Id:         1,
 					StartBlock: 0,
 					EndBlock:   0,
@@ -270,7 +273,7 @@ func TestBeginBlocker(t *testing.T) {
 						},
 					},
 				})
-
+				require.NoError(t, err)
 				params, err := s.keeper.Params.Get(s.ctx)
 				require.NoError(t, err)
 				params.StakingRewardRatio = math.LegacyOneDec().String()
@@ -285,7 +288,7 @@ func TestBeginBlocker(t *testing.T) {
 		{
 			name: "existing epochs with empty fee collector balance",
 			setup: func(s tallyFixture) {
-				s.keeper.SetEpoch(s.ctx, types.Epoch{
+				err := s.keeper.SetEpoch(s.ctx, types.Epoch{
 					Id:         1,
 					StartBlock: 0,
 					EndBlock:   0,
@@ -297,7 +300,7 @@ func TestBeginBlocker(t *testing.T) {
 						},
 					},
 				})
-
+				require.NoError(t, err)
 				s.mocks.BankKeeper.EXPECT().GetAllBalances(gomock.Any(), gomock.Any()).Return(sdk.Coins{}).AnyTimes()
 			},
 		},

--- a/x/liquidityincentive/keeper/abci_test.go
+++ b/x/liquidityincentive/keeper/abci_test.go
@@ -89,7 +89,8 @@ func TestCreateEpoch(t *testing.T) {
 			}
 
 			if len(tt.expectedTally) > 0 {
-				epochs := k.GetAllEpoch(ctx)
+				epochs, err := k.GetAllEpoch(ctx)
+				require.NoError(t, err)
 				require.Len(t, epochs, 1)
 				require.Equal(t, epochs[0].Id, uint64(1))
 				require.Equal(t, epochs[0].StartBlock, int64(0))
@@ -193,9 +194,11 @@ func TestEndBlocker(t *testing.T) {
 			}
 
 			if len(tt.expectedTally) > 0 {
-				epochs := k.GetAllEpoch(ctx)
+				epochs, err := k.GetAllEpoch(ctx)
+				require.NoError(t, err)
 				require.GreaterOrEqual(t, len(epochs), 1)
-				epoch, found := k.GetLastEpoch(ctx)
+				epoch, found, err := k.GetLastEpoch(ctx)
+				require.NoError(t, err)
 				require.True(t, found)
 				require.GreaterOrEqual(t, epoch.Id, uint64(1))
 				require.Equal(t, epoch.StartBlock, int64(0))

--- a/x/liquidityincentive/keeper/genesis.go
+++ b/x/liquidityincentive/keeper/genesis.go
@@ -10,14 +10,23 @@ import (
 func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) error {
 	// Set all the epoch
 	for _, elem := range genState.Epochs {
-		k.SetEpoch(ctx, elem)
+		err := k.SetEpoch(ctx, elem)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Set epoch count
-	k.SetEpochCount(ctx, genState.EpochCount)
+	err := k.SetEpochCount(ctx, genState.EpochCount)
+	if err != nil {
+		return err
+	}
 	// Set all the gauges
 	for _, elem := range genState.Gauges {
-		k.SetGauge(ctx, elem)
+		err := k.SetGauge(ctx, elem)
+		if err != nil {
+			return err
+		}
 	}
 	// Set all the votes
 	for _, vote := range genState.Votes {
@@ -45,7 +54,10 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 	if err != nil {
 		return nil, err
 	}
-	genesis.Gauges = k.GetAllGauges(ctx)
+	genesis.Gauges, err = k.GetAllGauges(ctx)
+	if err != nil {
+		return nil, err
+	}
 	genesis.Votes = k.GetAllVotes(ctx)
 
 	return genesis, nil

--- a/x/liquidityincentive/keeper/genesis.go
+++ b/x/liquidityincentive/keeper/genesis.go
@@ -30,7 +30,10 @@ func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) er
 	}
 	// Set all the votes
 	for _, vote := range genState.Votes {
-		k.SetVote(ctx, vote)
+		err := k.SetVote(ctx, vote)
+		if err != nil {
+			return err
+		}
 	}
 
 	return k.Params.Set(ctx, genState.Params)
@@ -58,7 +61,10 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 	if err != nil {
 		return nil, err
 	}
-	genesis.Votes = k.GetAllVotes(ctx)
+	genesis.Votes, err = k.GetAllVotes(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return genesis, nil
 }

--- a/x/liquidityincentive/keeper/genesis.go
+++ b/x/liquidityincentive/keeper/genesis.go
@@ -37,8 +37,14 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 		return nil, err
 	}
 
-	genesis.Epochs = k.GetAllEpoch(ctx)
-	genesis.EpochCount = k.GetEpochCount(ctx)
+	genesis.Epochs, err = k.GetAllEpoch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	genesis.EpochCount, err = k.GetEpochCount(ctx)
+	if err != nil {
+		return nil, err
+	}
 	genesis.Gauges = k.GetAllGauges(ctx)
 	genesis.Votes = k.GetAllVotes(ctx)
 

--- a/x/liquidityincentive/keeper/keeper_tally.go
+++ b/x/liquidityincentive/keeper/keeper_tally.go
@@ -45,7 +45,10 @@ func (k Keeper) Tally(ctx context.Context) ([]types.TallyResult, error) {
 		return []types.TallyResult{}, err
 	}
 
-	votes := k.GetAllVotes(ctx)
+	votes, err := k.GetAllVotes(ctx)
+	if err != nil {
+		return []types.TallyResult{}, err
+	}
 	for _, vote := range votes {
 		// if validator, just record it in the map
 		voter, err := k.accountKeeper.AddressCodec().StringToBytes(vote.Sender)

--- a/x/liquidityincentive/keeper/keeper_tally_test.go
+++ b/x/liquidityincentive/keeper/keeper_tally_test.go
@@ -36,10 +36,11 @@ var (
 		s.mocks.StakingKeeper.EXPECT().TotalBondedTokens(gomock.Any()).Return(sdkmath.NewInt(n), nil)
 	}
 	delegatorVote = func(s tallyFixture, voter sdk.AccAddress, delegations []stakingtypes.Delegation, weights []types.PoolWeight) {
-		s.keeper.SetVote(s.ctx, types.Vote{
+		err := s.keeper.SetVote(s.ctx, types.Vote{
 			Sender:      voter.String(),
 			PoolWeights: weights,
 		})
+		require.NoError(s.t, err)
 		s.mocks.StakingKeeper.EXPECT().
 			IterateDelegations(s.ctx, voter, gomock.Any()).
 			DoAndReturn(

--- a/x/liquidityincentive/keeper/msg_server_vote_gauge.go
+++ b/x/liquidityincentive/keeper/msg_server_vote_gauge.go
@@ -39,10 +39,13 @@ func (k msgServer) VoteGauge(ctx context.Context, msg *types.MsgVoteGauge) (*typ
 		}
 	}
 
-	k.SetVote(ctx, types.Vote{
+	err := k.SetVote(ctx, types.Vote{
 		Sender:      msg.Sender,
 		PoolWeights: msg.PoolWeights,
 	})
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to set vote")
+	}
 
 	if err := sdk.UnwrapSDKContext(ctx).EventManager().EmitTypedEvent(&types.EventVoteGauge{
 		Address:     msg.Sender,

--- a/x/liquidityincentive/keeper/query_epoch.go
+++ b/x/liquidityincentive/keeper/query_epoch.go
@@ -37,7 +37,10 @@ func (q queryServer) Epoch(ctx context.Context, req *types.QueryEpochRequest) (*
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	epoch, found := q.k.GetEpoch(ctx, req.Id)
+	epoch, found, err := q.k.GetEpoch(ctx, req.Id)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, sdkerrors.ErrKeyNotFound
 	}

--- a/x/liquidityincentive/keeper/query_gauge.go
+++ b/x/liquidityincentive/keeper/query_gauge.go
@@ -37,11 +37,14 @@ func (q queryServer) Gauge(ctx context.Context, req *types.QueryGaugeRequest) (*
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	val, found := q.k.GetGauge(
+	val, found, err := q.k.GetGauge(
 		ctx,
 		req.PreviousEpochId,
 		req.PoolId,
 	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "not found")
 	}

--- a/x/liquidityincentive/keeper/query_vote.go
+++ b/x/liquidityincentive/keeper/query_vote.go
@@ -37,10 +37,13 @@ func (q queryServer) Vote(ctx context.Context, req *types.QueryVoteRequest) (*ty
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	val, found := q.k.GetVote(
+	val, found, err := q.k.GetVote(
 		ctx,
 		req.Address,
 	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "not found")
 	}

--- a/x/liquidityincentive/keeper/store_gauge.go
+++ b/x/liquidityincentive/keeper/store_gauge.go
@@ -9,44 +9,46 @@ import (
 )
 
 // SetGauge set a specific gauge in the store from its index
-func (k Keeper) SetGauge(ctx context.Context, gauge types.Gauge) {
+func (k Keeper) SetGauge(ctx context.Context, gauge types.Gauge) error {
 	err := k.Gauges.Set(ctx, types.GaugeKey(gauge.PreviousEpochId, gauge.PoolId), gauge)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetGauge returns a gauge from its index
-func (k Keeper) GetGauge(ctx context.Context, previousEpochId uint64, poolId uint64) (val types.Gauge, found bool) {
+func (k Keeper) GetGauge(ctx context.Context, previousEpochId uint64, poolId uint64) (val types.Gauge, found bool, err error) {
 	key := types.GaugeKey(previousEpochId, poolId)
 	has, err := k.Gauges.Has(ctx, key)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
 	if !has {
-		return val, false
+		return val, false, nil
 	}
 
 	val, err = k.Gauges.Get(ctx, key)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // RemoveGauge removes a gauge from the store
-func (k Keeper) RemoveGauge(ctx context.Context, previousEpochId uint64, poolId uint64) {
+func (k Keeper) RemoveGauge(ctx context.Context, previousEpochId uint64, poolId uint64) error {
 	err := k.Gauges.Remove(ctx, types.GaugeKey(previousEpochId, poolId))
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetAllGauges returns all gauges
-func (k Keeper) GetAllGauges(ctx context.Context) (list []types.Gauge) {
-	err := k.Gauges.Walk(
+func (k Keeper) GetAllGauges(ctx context.Context) (list []types.Gauge, err error) {
+	err = k.Gauges.Walk(
 		ctx,
 		nil,
 		func(key collections.Pair[uint64, uint64], value types.Gauge) (bool, error) {
@@ -56,15 +58,15 @@ func (k Keeper) GetAllGauges(ctx context.Context) (list []types.Gauge) {
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }
 
 // GetAllGaugeByPreviousEpochId returns all gauges by previous epoch id
-func (k Keeper) GetAllGaugeByPreviousEpochId(ctx context.Context, previousEpochId uint64) (list []types.Gauge) {
-	err := k.Gauges.Walk(
+func (k Keeper) GetAllGaugeByPreviousEpochId(ctx context.Context, previousEpochId uint64) (list []types.Gauge, err error) {
+	err = k.Gauges.Walk(
 		ctx,
 		collections.NewPrefixedPairRange[uint64, uint64](previousEpochId),
 		func(key collections.Pair[uint64, uint64], value types.Gauge) (bool, error) {
@@ -74,8 +76,8 @@ func (k Keeper) GetAllGaugeByPreviousEpochId(ctx context.Context, previousEpochI
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }

--- a/x/liquidityincentive/keeper/store_vote.go
+++ b/x/liquidityincentive/keeper/store_vote.go
@@ -8,46 +8,48 @@ import (
 )
 
 // SetVote set a specific vote in the store from its index
-func (k Keeper) SetVote(ctx context.Context, vote types.Vote) {
+func (k Keeper) SetVote(ctx context.Context, vote types.Vote) error {
 	addr := sdk.MustAccAddressFromBech32(vote.Sender)
 	err := k.Votes.Set(ctx, addr, vote)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetVote returns a vote from its index
-func (k Keeper) GetVote(ctx context.Context, sender string) (val types.Vote, found bool) {
+func (k Keeper) GetVote(ctx context.Context, sender string) (val types.Vote, found bool, err error) {
 	addr := sdk.MustAccAddressFromBech32(sender)
 	has, err := k.Votes.Has(ctx, addr)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
 	if !has {
-		return val, false
+		return val, false, nil
 	}
 
 	val, err = k.Votes.Get(ctx, addr)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // RemoveVote removes a vote from the store
-func (k Keeper) RemoveVote(ctx context.Context, sender string) {
+func (k Keeper) RemoveVote(ctx context.Context, sender string) error {
 	addr := sdk.MustAccAddressFromBech32(sender)
 	err := k.Votes.Remove(ctx, addr)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetAllVotes returns all vote
-func (k Keeper) GetAllVotes(ctx context.Context) (list []types.Vote) {
-	err := k.Votes.Walk(
+func (k Keeper) GetAllVotes(ctx context.Context) (list []types.Vote, err error) {
+	err = k.Votes.Walk(
 		ctx,
 		nil,
 		func(key sdk.AccAddress, value types.Vote) (bool, error) {
@@ -57,8 +59,8 @@ func (k Keeper) GetAllVotes(ctx context.Context) (list []types.Vote) {
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }

--- a/x/liquiditypool/keeper/genesis.go
+++ b/x/liquiditypool/keeper/genesis.go
@@ -22,9 +22,15 @@ func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) er
 	}
 
 	// Set all the position
-	k.SetPositionCount(ctx, genState.PositionCount)
+	err = k.SetPositionCount(ctx, genState.PositionCount)
+	if err != nil {
+		return err
+	}
 	for _, elem := range genState.Positions {
-		k.SetPosition(ctx, elem)
+		err = k.SetPosition(ctx, elem)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Set all accumulators
@@ -67,8 +73,14 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 	if err != nil {
 		return nil, err
 	}
-	genesis.Positions = k.GetAllPositions(ctx)
-	genesis.PositionCount = k.GetPositionCount(ctx)
+	genesis.Positions, err = k.GetAllPositions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	genesis.PositionCount, err = k.GetPositionCount(ctx)
+	if err != nil {
+		return nil, err
+	}
 	genesis.Accumulators = k.GetAllAccumulators(ctx)
 	genesis.AccumulatorPositions = k.GetAllAccumulatorPositions(ctx)
 

--- a/x/liquiditypool/keeper/genesis.go
+++ b/x/liquiditypool/keeper/genesis.go
@@ -34,7 +34,10 @@ func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) er
 		if err != nil {
 			panic(err)
 		}
-		k.SetAccumulatorPosition(ctx, elem.Name, elem.AccumValuePerShare, elem.Index, numShares, elem.UnclaimedRewardsTotal)
+		err = k.SetAccumulatorPosition(ctx, elem.Name, elem.AccumValuePerShare, elem.Index, numShares, elem.UnclaimedRewardsTotal)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	return k.Params.Set(ctx, genState.Params)

--- a/x/liquiditypool/keeper/genesis.go
+++ b/x/liquiditypool/keeper/genesis.go
@@ -10,9 +10,15 @@ import (
 // InitGenesis initializes the module's state from a provided genesis state.
 func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) error {
 	// Set all the pool
-	k.SetPoolCount(ctx, genState.PoolCount)
+	err := k.SetPoolCount(ctx, genState.PoolCount)
+	if err != nil {
+		return err
+	}
 	for _, elem := range genState.Pools {
-		k.SetPool(ctx, elem)
+		err = k.SetPool(ctx, elem)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Set all the position
@@ -53,8 +59,14 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 		return nil, err
 	}
 
-	genesis.Pools = k.GetAllPools(ctx)
-	genesis.PoolCount = k.GetPoolCount(ctx)
+	genesis.Pools, err = k.GetAllPools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	genesis.PoolCount, err = k.GetPoolCount(ctx)
+	if err != nil {
+		return nil, err
+	}
 	genesis.Positions = k.GetAllPositions(ctx)
 	genesis.PositionCount = k.GetPositionCount(ctx)
 	genesis.Accumulators = k.GetAllAccumulators(ctx)

--- a/x/liquiditypool/keeper/keeper_accumulator_test.go
+++ b/x/liquiditypool/keeper/keeper_accumulator_test.go
@@ -33,7 +33,8 @@ func TestAccumulatorStore(t *testing.T) {
 	require.Equal(t, accumulator.AccumValue.String(), "")
 	require.Equal(t, accumulator.TotalShares, "0.000000000000000000")
 
-	k.AddToAccumulator(ctx, accumulator, sdk.NewDecCoins(sdk.NewDecCoin("denom", math.NewInt(100))))
+	err = k.AddToAccumulator(ctx, accumulator, sdk.NewDecCoins(sdk.NewDecCoin("denom", math.NewInt(100))))
+	require.NoError(t, err)
 	accumulator, err = k.GetAccumulator(ctx, "accumulator2")
 	require.NoError(t, err)
 	require.Equal(t, accumulator.Name, "accumulator2")
@@ -70,7 +71,8 @@ func TestAccumulatorPositionStore(t *testing.T) {
 
 	accmulatorValuePerShare := sdk.NewDecCoins(sdk.NewDecCoin("denom", math.NewInt(1)))
 	unclaimedRewardsTotal := sdk.NewDecCoins(sdk.NewDecCoin("denom", math.NewInt(2)))
-	k.SetAccumulatorPosition(ctx, "accumulator", accmulatorValuePerShare, "index", math.LegacyOneDec(), unclaimedRewardsTotal)
+	err = k.SetAccumulatorPosition(ctx, "accumulator", accmulatorValuePerShare, "index", math.LegacyOneDec(), unclaimedRewardsTotal)
+	require.NoError(t, err)
 	position, err := k.GetAccumulatorPosition(ctx, "accumulator", "index")
 	require.NoError(t, err)
 	require.Equal(t, position.Name, "accumulator")
@@ -79,7 +81,8 @@ func TestAccumulatorPositionStore(t *testing.T) {
 	require.Equal(t, position.AccumValuePerShare.String(), "1.000000000000000000denom")
 	require.Equal(t, position.UnclaimedRewardsTotal.String(), "2.000000000000000000denom")
 
-	k.SetAccumulatorPosition(ctx, "accumulator", accmulatorValuePerShare, "index2", math.LegacyOneDec(), unclaimedRewardsTotal)
+	err = k.SetAccumulatorPosition(ctx, "accumulator", accmulatorValuePerShare, "index2", math.LegacyOneDec(), unclaimedRewardsTotal)
+	require.NoError(t, err)
 	position, err = k.GetAccumulatorPosition(ctx, "accumulator", "index2")
 	require.NoError(t, err)
 	require.Equal(t, position.Name, "accumulator")
@@ -88,7 +91,8 @@ func TestAccumulatorPositionStore(t *testing.T) {
 	require.Equal(t, position.AccumValuePerShare.String(), "1.000000000000000000denom")
 	require.Equal(t, position.UnclaimedRewardsTotal.String(), "2.000000000000000000denom")
 
-	k.SetAccumulatorPosition(ctx, "accumulator2", accmulatorValuePerShare, "index", math.LegacyOneDec(), unclaimedRewardsTotal)
+	err = k.SetAccumulatorPosition(ctx, "accumulator2", accmulatorValuePerShare, "index", math.LegacyOneDec(), unclaimedRewardsTotal)
+	require.NoError(t, err)
 	position, err = k.GetAccumulatorPosition(ctx, "accumulator2", "index")
 	require.NoError(t, err)
 	require.Equal(t, position.Name, "accumulator2")

--- a/x/liquiditypool/keeper/keeper_fee.go
+++ b/x/liquiditypool/keeper/keeper_fee.go
@@ -187,7 +187,10 @@ func (k Keeper) prepareClaimableFees(ctx sdk.Context, positionId uint64) (sdk.Co
 		}
 		if !totalSharesRemaining.IsZero() {
 			forfeitedDustPerShareScaled := forfeitedDust.QuoDecTruncate(totalSharesRemaining)
-			k.AddToAccumulator(ctx, feeAccumulator, forfeitedDustPerShareScaled)
+			err = k.AddToAccumulator(ctx, feeAccumulator, forfeitedDustPerShareScaled)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/x/liquiditypool/keeper/keeper_incentives.go
+++ b/x/liquiditypool/keeper/keeper_incentives.go
@@ -20,7 +20,10 @@ func (k Keeper) AllocateIncentive(ctx sdk.Context, poolId uint64, sender sdk.Acc
 		return err
 	}
 	feeGrowth := sdk.NewDecCoinsFromCoins(incentiveCoins...).QuoDecTruncate(liquidity)
-	k.AddToAccumulator(ctx, feeAccumulator, feeGrowth)
+	err = k.AddToAccumulator(ctx, feeAccumulator, feeGrowth)
+	if err != nil {
+		return err
+	}
 
 	return k.bankKeeper.SendCoins(ctx, sender, pool.GetFeesAddress(), incentiveCoins)
 }

--- a/x/liquiditypool/keeper/keeper_swap.go
+++ b/x/liquiditypool/keeper/keeper_swap.go
@@ -577,9 +577,12 @@ func (k Keeper) updatePoolForSwap(
 		return fmt.Errorf("error applying swap: %w", err)
 	}
 
-	k.SetPool(ctx, pool)
+	err = k.SetPool(ctx, pool)
+	if err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func isBaseForQuote(inDenom, assetBase string) bool {
@@ -624,7 +627,10 @@ func (k Keeper) setupSwapHelper(p types.Pool, feeRate math.LegacyDec, denomIn st
 }
 
 func (k Keeper) getPoolForSwap(ctx sdk.Context, poolId uint64) (types.Pool, error) {
-	p, found := k.GetPool(ctx, poolId)
+	p, found, err := k.GetPool(ctx, poolId)
+	if err != nil {
+		return p, err
+	}
 	if !found {
 		return p, types.ErrPoolNotFound
 	}

--- a/x/liquiditypool/keeper/keeper_swap.go
+++ b/x/liquiditypool/keeper/keeper_swap.go
@@ -384,7 +384,10 @@ func (k Keeper) computeOutAmtGivenIn(
 
 	if updateAccumulators {
 		feeGrowth := sdk.DecCoin{Denom: minTokenIn.Denom, Amount: swapState.globalFeeGrowthPerUnitLiquidity}
-		k.AddToAccumulator(ctx, feeAccumulator, sdk.NewDecCoins(feeGrowth))
+		err = k.AddToAccumulator(ctx, feeAccumulator, sdk.NewDecCoins(feeGrowth))
+		if err != nil {
+			return SwapResult{}, PoolUpdates{}, err
+		}
 	}
 
 	amountIn := minTokenIn.Amount.ToLegacyDec().SubMut(swapState.amountSpecifiedRemaining).Ceil().TruncateInt()
@@ -483,7 +486,10 @@ func (k Keeper) computeInAmtGivenOut(
 	}
 
 	if updateAccumulators {
-		k.AddToAccumulator(ctx, feeAccumulator, sdk.NewDecCoins(sdk.NewDecCoinFromDec(denomIn, swapState.globalFeeGrowthPerUnitLiquidity)))
+		err = k.AddToAccumulator(ctx, feeAccumulator, sdk.NewDecCoins(sdk.NewDecCoinFromDec(denomIn, swapState.globalFeeGrowthPerUnitLiquidity)))
+		if err != nil {
+			return SwapResult{}, PoolUpdates{}, err
+		}
 	}
 
 	amountIn := swapState.amountCalculated.Ceil().TruncateInt()

--- a/x/liquiditypool/keeper/keeper_swap_test.go
+++ b/x/liquiditypool/keeper/keeper_swap_test.go
@@ -122,7 +122,8 @@ func TestSwapExactAmountIn_SinglePosition(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			pool, found := k.GetPool(ctx, 0)
+			pool, found, err := k.GetPool(ctx, 0)
+			require.NoError(t, err)
 			require.True(t, found)
 
 			amountOut, err := k.SwapExactAmountIn(wctx, sender, pool, tc.tokenIn, tc.denomOut, tc.feeEnabled)
@@ -131,7 +132,8 @@ func TestSwapExactAmountIn_SinglePosition(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 
-				pool, found := k.GetPool(ctx, 0)
+				pool, found, err = k.GetPool(ctx, 0)
+				require.NoError(t, err)
 				require.True(t, found)
 				require.Equal(t, amountOut.String(), tc.expAmountOut.String())
 				require.Equal(t, pool.CurrentTick, tc.expTickIndex)
@@ -210,7 +212,8 @@ func TestSwapExactAmountIn_MultiplePositions(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			pool, found := k.GetPool(ctx, 0)
+			pool, found, err := k.GetPool(ctx, 0)
+			require.NoError(t, err)
 			require.True(t, found)
 
 			amountOut, err := k.SwapExactAmountIn(wctx, sender, pool, tc.tokenIn, tc.denomOut, tc.feeEnabled)
@@ -220,7 +223,8 @@ func TestSwapExactAmountIn_MultiplePositions(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, amountOut.String(), tc.expAmountOut.String())
 
-				pool, found := k.GetPool(ctx, 0)
+				pool, found, err = k.GetPool(ctx, 0)
+				require.NoError(t, err)
 				require.True(t, found)
 				require.Equal(t, pool.CurrentTick, tc.expTickIndex)
 			}
@@ -326,7 +330,8 @@ func TestSwapExactAmountOut_SinglePosition(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			pool, found := k.GetPool(ctx, 0)
+			pool, found, err := k.GetPool(ctx, 0)
+			require.NoError(t, err)
 			require.True(t, found)
 
 			amountIn, err := k.SwapExactAmountOut(wctx, sender, pool, tc.tokenOut, tc.denomIn, tc.feeEnabled)
@@ -335,7 +340,8 @@ func TestSwapExactAmountOut_SinglePosition(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 
-				pool, found := k.GetPool(ctx, 0)
+				pool, found, err = k.GetPool(ctx, 0)
+				require.NoError(t, err)
 				require.True(t, found)
 				require.Equal(t, amountIn.String(), tc.expAmountIn.String())
 				require.Equal(t, pool.CurrentTick, tc.expTickIndex)
@@ -414,7 +420,8 @@ func TestSwapExactAmountOut_MultiplePositions(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			pool, found := k.GetPool(ctx, 0)
+			pool, found, err := k.GetPool(ctx, 0)
+			require.NoError(t, err)
 			require.True(t, found)
 
 			amountIn, err := k.SwapExactAmountOut(wctx, sender, pool, tc.tokenOut, tc.denomIn, tc.feeEnabled)
@@ -424,7 +431,8 @@ func TestSwapExactAmountOut_MultiplePositions(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, amountIn.String(), tc.expAmountIn.String())
 
-				pool, found := k.GetPool(ctx, 0)
+				pool, found, err = k.GetPool(ctx, 0)
+				require.NoError(t, err)
 				require.True(t, found)
 				require.Equal(t, pool.CurrentTick, tc.expTickIndex)
 			}
@@ -441,7 +449,7 @@ func TestGetValidatedPoolAndAccumulator(t *testing.T) {
 	require.Error(t, err)
 
 	// when accumulator does not exist
-	k.SetPool(ctx, types.Pool{
+	err = k.SetPool(ctx, types.Pool{
 		Id:                   1,
 		DenomBase:            "base",
 		DenomQuote:           "quote",
@@ -451,6 +459,9 @@ func TestGetValidatedPoolAndAccumulator(t *testing.T) {
 		CurrentTickLiquidity: math.LegacyOneDec().String(),
 		CurrentSqrtPrice:     math.LegacyOneDec().String(),
 	})
+	if err != nil {
+		t.Fatalf("failed to set pool: %v", err)
+	}
 	_, _, err = k.GetValidatedPoolAndAccumulator(ctx, 1, "base", "quote")
 	require.Error(t, err)
 
@@ -573,7 +584,8 @@ func TestCalculateResultExactAmountOut(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			pool, found := k.GetPool(ctx, 0)
+			pool, found, err := k.GetPool(ctx, 0)
+			require.NoError(t, err)
 			require.True(t, found)
 
 			amountIn, err := k.CalculateResultExactAmountOut(wctx, pool, tc.tokenOut, tc.denomIn, tc.feeEnabled)
@@ -685,7 +697,8 @@ func TestCalculateResultExactAmountIn(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			pool, found := k.GetPool(ctx, 0)
+			pool, found, err := k.GetPool(ctx, 0)
+			require.NoError(t, err)
 			require.True(t, found)
 
 			amountOut, err := k.CalculateResultExactAmountIn(wctx, pool, tc.tokenIn, tc.denomOut, tc.feeEnabled)

--- a/x/liquiditypool/keeper/keeper_tick.go
+++ b/x/liquiditypool/keeper/keeper_tick.go
@@ -58,7 +58,10 @@ func (k Keeper) CrossTick(ctx sdk.Context, poolId uint64, tickIndex int64, tickI
 }
 
 func (k Keeper) NewTickInfo(ctx context.Context, poolId uint64, tickIndex int64) (tickInfo types.TickInfo, err error) {
-	pool, found := k.GetPool(ctx, poolId)
+	pool, found, err := k.GetPool(ctx, poolId)
+	if err != nil {
+		return tickInfo, err
+	}
 	if !found {
 		return tickInfo, types.ErrPoolNotFound
 	}

--- a/x/liquiditypool/keeper/msg_server_create_pool.go
+++ b/x/liquiditypool/keeper/msg_server_create_pool.go
@@ -25,17 +25,17 @@ func (k msgServer) CreatePool(ctx context.Context, msg *types.MsgCreatePool) (*t
 
 	feeRate, err := math.LegacyNewDecFromStr(msg.FeeRate)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "invalid fee rate")
 	}
 
 	priceRatio, err := math.LegacyNewDecFromStr(msg.PriceRatio)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "invalid price ratio")
 	}
 
 	baseOffset, err := math.LegacyNewDecFromStr(msg.BaseOffset)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "invalid base offset")
 	}
 
 	var pool = types.Pool{
@@ -50,9 +50,12 @@ func (k msgServer) CreatePool(ctx context.Context, msg *types.MsgCreatePool) (*t
 		CurrentTickLiquidity: math.LegacyZeroDec().String(),
 		CurrentSqrtPrice:     math.LegacyZeroDec().String(),
 	}
-	id := k.AppendPool(ctx, pool)
+	id, err := k.AppendPool(ctx, pool)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to append pool")
+	}
 	if err := k.createFeeAccumulator(ctx, id); err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to create fee accumulator")
 	}
 
 	if err := sdk.UnwrapSDKContext(ctx).EventManager().EmitTypedEvent(&types.EventCreatePool{

--- a/x/liquiditypool/keeper/msg_server_create_position.go
+++ b/x/liquiditypool/keeper/msg_server_create_position.go
@@ -20,9 +20,12 @@ func (k msgServer) CreatePosition(ctx context.Context, msg *types.MsgCreatePosit
 
 	sender, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "invalid sender address")
 	}
-	pool, found := k.GetPool(ctx, msg.PoolId)
+	pool, found, err := k.GetPool(ctx, msg.PoolId)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to get pool")
+	}
 	if !found {
 		return nil, errorsmod.Wrapf(types.ErrPoolNotFound, "pool id: %d", msg.PoolId)
 	}
@@ -53,23 +56,29 @@ func (k msgServer) CreatePosition(ctx context.Context, msg *types.MsgCreatePosit
 
 	sqrtPriceLowerTick, sqrtPriceUpperTick, err := types.TicksToSqrtPrice(msg.LowerTick, msg.UpperTick, pool.TickParams)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to get sqrt price")
 	}
 
 	hasPositions := pool.HasPosition(sdkCtx)
 	if !hasPositions {
 		err := k.initFirstPositionForPool(sdkCtx, pool, amountBaseDesired, amountQuoteDesired)
 		if err != nil {
-			return nil, err
+			return nil, errorsmod.Wrap(err, "failed to init first position for pool")
 		}
 		// Get updated pool after initialization
-		pool, _ = k.GetPool(ctx, msg.PoolId)
+		pool, found, err = k.GetPool(ctx, msg.PoolId)
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "failed to get pool")
+		}
+		if !found {
+			return nil, errorsmod.Wrapf(types.ErrPoolNotFound, "pool id: %d", msg.PoolId)
+		}
 	}
 
 	// Calculate the amount of liquidity that will be added to the pool when this position is created.
 	currentSqrtPrice, err := math.LegacyNewDecFromStr(pool.CurrentSqrtPrice)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to get current sqrt price")
 	}
 	liquidityDelta := types.GetLiquidityFromAmounts(currentSqrtPrice, sqrtPriceLowerTick, sqrtPriceUpperTick, amountBaseDesired, amountQuoteDesired)
 	if liquidityDelta.IsZero() {
@@ -89,7 +98,7 @@ func (k msgServer) CreatePosition(ctx context.Context, msg *types.MsgCreatePosit
 	// Initialize / update the position in the pool based on the provided tick range and liquidity delta.
 	amountBase, amountQuote, _, _, err := k.UpdatePosition(sdkCtx, position.PoolId, sender, position.LowerTick, position.UpperTick, liquidityDelta, positionId)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to update position")
 	}
 
 	// Check if the actual amounts are greater than or equal to minimum amounts
@@ -104,11 +113,11 @@ func (k msgServer) CreatePosition(ctx context.Context, msg *types.MsgCreatePosit
 	coins := sdk.Coins{sdk.NewCoin(msg.TokenBase.Denom, amountBase)}
 	coins = coins.Add(sdk.NewCoin(msg.TokenQuote.Denom, amountQuote))
 	if err := k.bankKeeper.IsSendEnabledCoins(ctx, coins...); err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to check if send enabled coins")
 	}
 	err = k.bankKeeper.SendCoins(ctx, sender, pool.GetAddress(), coins)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to send coins")
 	}
 
 	position, _ = k.GetPosition(ctx, positionId)

--- a/x/liquiditypool/keeper/msg_server_increase_liquidity.go
+++ b/x/liquiditypool/keeper/msg_server_increase_liquidity.go
@@ -40,21 +40,24 @@ func (k msgServer) IncreaseLiquidity(ctx context.Context, msg *types.MsgIncrease
 	// Remove full position liquidity
 	sender, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "invalid sender address")
 	}
 	liquidity, err := math.LegacyNewDecFromStr(position.Liquidity)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "invalid liquidity")
 	}
 
 	amountBaseWithdrawn, amountQuoteWithdrawn, err := k.Keeper.DecreaseLiquidity(sdkCtx, sender, msg.Id, liquidity)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to decrease liquidity")
 	}
 
-	pool, found := k.GetPool(ctx, position.PoolId)
+	pool, found, err := k.GetPool(ctx, position.PoolId)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to get pool")
+	}
 	if !found {
-		return nil, types.ErrPoolNotFound
+		return nil, errorsmod.Wrapf(types.ErrPoolNotFound, "pool id: %d", position.PoolId)
 	}
 
 	// Create a new position with combined liquidity
@@ -74,7 +77,7 @@ func (k msgServer) IncreaseLiquidity(ctx context.Context, msg *types.MsgIncrease
 		MinAmountQuote: minAmountQuote,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to create position")
 	}
 
 	if err := sdk.UnwrapSDKContext(ctx).EventManager().EmitTypedEvent(&types.EventIncreaseLiquidity{

--- a/x/liquiditypool/keeper/msg_server_increase_liquidity.go
+++ b/x/liquiditypool/keeper/msg_server_increase_liquidity.go
@@ -20,7 +20,10 @@ func (k msgServer) IncreaseLiquidity(ctx context.Context, msg *types.MsgIncrease
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	position, found := k.GetPosition(ctx, msg.Id)
+	position, found, err := k.GetPosition(ctx, msg.Id)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err, "failed to get position: %d", msg.Id)
+	}
 	if !found {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrKeyNotFound, "key %d doesn't exist", msg.Id)
 	}

--- a/x/liquiditypool/keeper/msg_server_pool_test.go
+++ b/x/liquiditypool/keeper/msg_server_pool_test.go
@@ -26,7 +26,8 @@ func TestPoolMsgServerCreate(t *testing.T) {
 	require.Equal(t, uint64(0), resp.Id)
 
 	// check created pool and status
-	pool, found := k.GetPool(ctx, resp.Id)
+	pool, found, err := k.GetPool(ctx, resp.Id)
+	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, pool.TickParams.PriceRatio, "1.000100000000000000")
 	require.Equal(t, pool.TickParams.BaseOffset, "0.500000000000000000")

--- a/x/liquiditypool/keeper/query_calculations.go
+++ b/x/liquiditypool/keeper/query_calculations.go
@@ -92,7 +92,10 @@ func (q queryServer) CalculationIncreaseLiquidity(ctx context.Context, req *type
 		return nil, types.ErrInvalidTokenAmounts
 	}
 
-	position, found := q.k.GetPosition(ctx, req.Id)
+	position, found, err := q.k.GetPosition(ctx, req.Id)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, types.ErrPositionNotFound
 	}

--- a/x/liquiditypool/keeper/query_calculations.go
+++ b/x/liquiditypool/keeper/query_calculations.go
@@ -16,7 +16,10 @@ func (q queryServer) CalculationCreatePosition(ctx context.Context, req *types.Q
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	pool, found := q.k.GetPool(ctx, req.PoolId)
+	pool, found, err := q.k.GetPool(ctx, req.PoolId)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, types.ErrPoolNotFound
 	}
@@ -29,7 +32,7 @@ func (q queryServer) CalculationCreatePosition(ctx context.Context, req *types.Q
 	if !ok {
 		return nil, types.ErrInvalidTickers
 	}
-	err := types.CheckTicks(lowerTick.Int64(), upperTick.Int64())
+	err = types.CheckTicks(lowerTick.Int64(), upperTick.Int64())
 	if err != nil {
 		return nil, types.ErrInvalidTickers
 	}
@@ -93,7 +96,10 @@ func (q queryServer) CalculationIncreaseLiquidity(ctx context.Context, req *type
 	if !found {
 		return nil, types.ErrPositionNotFound
 	}
-	pool, found := q.k.GetPool(ctx, position.PoolId)
+	pool, found, err := q.k.GetPool(ctx, position.PoolId)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, types.ErrPoolNotFound
 	}

--- a/x/liquiditypool/keeper/query_pool.go
+++ b/x/liquiditypool/keeper/query_pool.go
@@ -47,7 +47,10 @@ func (q queryServer) Pool(ctx context.Context, req *types.QueryPoolRequest) (*ty
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	pool, found := q.k.GetPool(ctx, req.Id)
+	pool, found, err := q.k.GetPool(ctx, req.Id)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, sdkerrors.ErrKeyNotFound
 	}

--- a/x/liquiditypool/keeper/query_position.go
+++ b/x/liquiditypool/keeper/query_position.go
@@ -64,7 +64,10 @@ func (q queryServer) Position(ctx context.Context, req *types.QueryPositionReque
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	position, found := q.k.GetPosition(ctx, req.Id)
+	position, found, err := q.k.GetPosition(ctx, req.Id)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, sdkerrors.ErrKeyNotFound
 	}
@@ -78,7 +81,10 @@ func (q queryServer) PoolPositions(ctx context.Context, req *types.QueryPoolPosi
 	}
 
 	positionInfos := []types.PositionInfo{}
-	positions := q.k.GetPositionsByPool(ctx, req.PoolId)
+	positions, err := q.k.GetPositionsByPool(ctx, req.PoolId)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	for _, position := range positions {
 		positionInfos = append(positionInfos, q.k.WrapPositionInfo(ctx, position))
 	}
@@ -97,7 +103,10 @@ func (q queryServer) AddressPositions(ctx context.Context, req *types.QueryAddre
 	}
 
 	positionInfos := []types.PositionInfo{}
-	positions := q.k.GetPositionsByAddress(ctx, addr)
+	positions, err := q.k.GetPositionsByAddress(ctx, addr)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	for _, position := range positions {
 		positionInfos = append(positionInfos, q.k.WrapPositionInfo(ctx, position))
 	}

--- a/x/liquiditypool/keeper/query_position.go
+++ b/x/liquiditypool/keeper/query_position.go
@@ -14,7 +14,10 @@ import (
 )
 
 func (k Keeper) WrapPositionInfo(ctx context.Context, position types.Position) types.PositionInfo {
-	pool, found := k.GetPool(ctx, position.PoolId)
+	pool, found, err := k.GetPool(ctx, position.PoolId)
+	if err != nil {
+		return types.PositionInfo{Position: position}
+	}
 	if !found {
 		return types.PositionInfo{Position: position}
 	}

--- a/x/liquiditypool/keeper/store_pool.go
+++ b/x/liquiditypool/keeper/store_pool.go
@@ -7,76 +7,82 @@ import (
 )
 
 // GetPoolCount get the total number of pool
-func (k Keeper) GetPoolCount(ctx context.Context) uint64 {
-	val, err := k.PoolId.Peek(ctx)
+func (k Keeper) GetPoolCount(ctx context.Context) (count uint64, err error) {
+	count, err = k.PoolId.Peek(ctx)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
-	return val
+	return count, nil
 }
 
 // SetPoolCount set the total number of pool
-func (k Keeper) SetPoolCount(ctx context.Context, count uint64) {
+func (k Keeper) SetPoolCount(ctx context.Context, count uint64) error {
 	err := k.PoolId.Set(ctx, count)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // AppendPool appends a pool in the store with a new id and update the count
-func (k Keeper) AppendPool(ctx context.Context, pool types.Pool) uint64 {
+func (k Keeper) AppendPool(ctx context.Context, pool types.Pool) (id uint64, err error) {
 	// Create the pool
-	id, err := k.PoolId.Next(ctx)
+	id, err = k.PoolId.Next(ctx)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
 	// Set the ID of the appended value
 	pool.Id = id
-	k.SetPool(ctx, pool)
+	err = k.SetPool(ctx, pool)
+	if err != nil {
+		return 0, err
+	}
 
-	return id
+	return id, nil
 }
 
 // SetPool set a specific pool in the store
-func (k Keeper) SetPool(ctx context.Context, pool types.Pool) {
+func (k Keeper) SetPool(ctx context.Context, pool types.Pool) error {
 	err := k.Pools.Set(ctx, pool.Id, pool)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetPool returns a pool from its id
-func (k Keeper) GetPool(ctx context.Context, id uint64) (val types.Pool, found bool) {
+func (k Keeper) GetPool(ctx context.Context, id uint64) (val types.Pool, found bool, err error) {
 	has, err := k.Pools.Has(ctx, id)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
 	if !has {
-		return val, false
+		return val, false, nil
 	}
 
 	val, err = k.Pools.Get(ctx, id)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // RemovePool removes a pool from the store
-func (k Keeper) RemovePool(ctx context.Context, id uint64) {
+func (k Keeper) RemovePool(ctx context.Context, id uint64) error {
 	err := k.Pools.Remove(ctx, id)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetAllPools returns all pool
-func (k Keeper) GetAllPools(ctx context.Context) (list []types.Pool) {
-	err := k.Pools.Walk(
+func (k Keeper) GetAllPools(ctx context.Context) (list []types.Pool, err error) {
+	err = k.Pools.Walk(
 		ctx,
 		nil,
 		func(key uint64, value types.Pool) (bool, error) {
@@ -86,7 +92,7 @@ func (k Keeper) GetAllPools(ctx context.Context) (list []types.Pool) {
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return

--- a/x/liquiditypool/keeper/store_position.go
+++ b/x/liquiditypool/keeper/store_position.go
@@ -10,76 +10,85 @@ import (
 )
 
 // GetPositionCount get the total number of position
-func (k Keeper) GetPositionCount(ctx context.Context) uint64 {
-	val, err := k.PositionId.Peek(ctx)
+func (k Keeper) GetPositionCount(ctx context.Context) (count uint64, err error) {
+	count, err = k.PositionId.Peek(ctx)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
-	return val
+	return count, nil
 }
 
 // SetPositionCount set the total number of position
-func (k Keeper) SetPositionCount(ctx context.Context, count uint64) {
+func (k Keeper) SetPositionCount(ctx context.Context, count uint64) error {
 	err := k.PositionId.Set(ctx, count)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // AppendPosition appends a position in the store with a new id and update the count
-func (k Keeper) AppendPosition(ctx context.Context, position types.Position) uint64 {
+func (k Keeper) AppendPosition(ctx context.Context, position types.Position) (id uint64, err error) {
 	// Create the position
-	id, err := k.PositionId.Next(ctx)
+	id, err = k.PositionId.Next(ctx)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
 	// Set the ID of the appended value
 	position.Id = id
-	k.SetPosition(ctx, position)
+	err = k.SetPosition(ctx, position)
+	if err != nil {
+		return 0, err
+	}
 
-	return id
+	return id, nil
 }
 
 // SetPosition set a specific position in the store
-func (k Keeper) SetPosition(ctx context.Context, position types.Position) {
+func (k Keeper) SetPosition(ctx context.Context, position types.Position) error {
 	err := k.Positions.Set(ctx, position.Id, position)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // GetPosition returns a position from its id
-func (k Keeper) GetPosition(ctx context.Context, id uint64) (val types.Position, found bool) {
+func (k Keeper) GetPosition(ctx context.Context, id uint64) (val types.Position, found bool, err error) {
 	has, err := k.Positions.Has(ctx, id)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
 	if !has {
-		return val, false
+		return val, false, nil
 	}
 
 	val, err = k.Positions.Get(ctx, id)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // RemovePosition removes a position from the store
-func (k Keeper) RemovePosition(ctx context.Context, id uint64) {
+func (k Keeper) RemovePosition(ctx context.Context, id uint64) error {
 	err := k.Positions.Remove(ctx, id)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // GetAllPositions returns all position
-func (k Keeper) GetAllPositions(ctx context.Context) (list []types.Position) {
-	err := k.Positions.Walk(
+func (k Keeper) GetAllPositions(ctx context.Context) (list []types.Position, err error) {
+	err = k.Positions.Walk(
 		ctx,
 		nil,
 		func(key uint64, value types.Position) (bool, error) {
@@ -89,58 +98,64 @@ func (k Keeper) GetAllPositions(ctx context.Context) (list []types.Position) {
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }
 
-func (k Keeper) PoolHasPosition(ctx context.Context, poolId uint64) bool {
+func (k Keeper) PoolHasPosition(ctx context.Context, poolId uint64) (bool, error) {
 	iterator, err := k.Positions.Indexes.PoolId.Iterate(
 		ctx,
 		collections.NewPrefixedPairRange[uint64, uint64](poolId),
 	)
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 
 	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
-func (k Keeper) GetPositionsByPool(ctx context.Context, poolId uint64) (list []types.Position) {
-	err := k.Positions.Indexes.PoolId.Walk(
+func (k Keeper) GetPositionsByPool(ctx context.Context, poolId uint64) (list []types.Position, err error) {
+	err = k.Positions.Indexes.PoolId.Walk(
 		ctx,
 		collections.NewPrefixedPairRange[uint64, uint64](poolId),
 		func(_ uint64, positionId uint64) (bool, error) {
-			value, _ := k.GetPosition(ctx, positionId)
+			value, _, err := k.GetPosition(ctx, positionId)
+			if err != nil {
+				return false, err
+			}
 			list = append(list, value)
 			return false, nil
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return
 }
 
-func (k Keeper) GetPositionsByAddress(ctx context.Context, addr sdk.AccAddress) (list []types.Position) {
-	err := k.Positions.Indexes.Address.Walk(
+func (k Keeper) GetPositionsByAddress(ctx context.Context, addr sdk.AccAddress) (list []types.Position, err error) {
+	err = k.Positions.Indexes.Address.Walk(
 		ctx,
 		collections.NewPrefixedPairRange[sdk.AccAddress, uint64](addr),
 		func(_ sdk.AccAddress, positionId uint64) (bool, error) {
-			value, _ := k.GetPosition(ctx, positionId)
+			value, _, err := k.GetPosition(ctx, positionId)
+			if err != nil {
+				return false, err
+			}
 			list = append(list, value)
 			return false, nil
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return

--- a/x/liquiditypool/types/tick_test.go
+++ b/x/liquiditypool/types/tick_test.go
@@ -125,11 +125,11 @@ func TestGetSqrtPriceFromQuoteBase(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, sqrtPrice.String(), "0.100000000000000000")
 
-	sqrtPrice, err = GetSqrtPriceFromQuoteBase(math.NewInt(1), Multiplier.RoundInt())
+	sqrtPrice, err = GetSqrtPriceFromQuoteBase(math.NewInt(1), Multiplier.TruncateInt())
 	require.NoError(t, err)
 	require.Equal(t, sqrtPrice.String(), "0.000000001000000000")
 
-	sqrtPrice, err = GetSqrtPriceFromQuoteBase(math.NewInt(1), Multiplier.Mul(Multiplier).RoundInt())
+	sqrtPrice, err = GetSqrtPriceFromQuoteBase(math.NewInt(1), Multiplier.Mul(Multiplier).TruncateInt())
 	require.NoError(t, err)
 	require.Equal(t, sqrtPrice.String(), "0.000000000000000001")
 }

--- a/x/swap/keeper/genesis.go
+++ b/x/swap/keeper/genesis.go
@@ -30,8 +30,14 @@ func (k Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) 
 		return nil, err
 	}
 
-	genesis.IncomingInFlightPackets = k.GetIncomingInFlightPackets(ctx)
-	genesis.OutgoingInFlightPackets = k.GetOutgoingInFlightPackets(ctx)
+	genesis.IncomingInFlightPackets, err = k.GetIncomingInFlightPackets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	genesis.OutgoingInFlightPackets, err = k.GetOutgoingInFlightPackets(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return genesis, nil
 }

--- a/x/swap/keeper/ibc.go
+++ b/x/swap/keeper/ibc.go
@@ -241,7 +241,10 @@ func (k Keeper) OnAcknowledgementOutgoingInFlightPacket(
 	acknowledgement []byte,
 	outgoingPacket types.OutgoingInFlightPacket,
 ) error {
-	incomingPacket, found := k.GetIncomingInFlightPacket(ctx, outgoingPacket.AckWaitingIndex.PortId, outgoingPacket.AckWaitingIndex.ChannelId, outgoingPacket.AckWaitingIndex.Sequence)
+	incomingPacket, found, err := k.GetIncomingInFlightPacket(ctx, outgoingPacket.AckWaitingIndex.PortId, outgoingPacket.AckWaitingIndex.ChannelId, outgoingPacket.AckWaitingIndex.Sequence)
+	if err != nil {
+		return err
+	}
 	if found {
 		k.RemoveOutgoingInFlightPacket(ctx, outgoingPacket.Index.PortId, outgoingPacket.Index.ChannelId, outgoingPacket.Index.Sequence)
 	} else {
@@ -317,7 +320,10 @@ func (k Keeper) OnTimeoutOutgoingInFlightPacket(
 		// - However it contains error acknowledgement of change / forward packet
 		ack := channeltypes.NewErrorAcknowledgement(errors.Wrap(sdkerrors.ErrUnknownRequest, "Retry count on timeout exceeds"))
 
-		waitingPacket, found := k.GetIncomingInFlightPacket(ctx, outgoingPacket.AckWaitingIndex.PortId, outgoingPacket.AckWaitingIndex.ChannelId, outgoingPacket.AckWaitingIndex.Sequence)
+		waitingPacket, found, err := k.GetIncomingInFlightPacket(ctx, outgoingPacket.AckWaitingIndex.PortId, outgoingPacket.AckWaitingIndex.ChannelId, outgoingPacket.AckWaitingIndex.Sequence)
+		if err != nil {
+			return err
+		}
 		if !found {
 			return nil
 		}
@@ -399,9 +405,9 @@ func (k Keeper) ShouldDeleteCompletedWaitingPacket(
 	}
 
 	// _, chanCap, err := k.IbcKeeperFn().ChannelKeeper.LookupModuleByChannel(ctx, packet.Index.PortId, packet.Index.ChannelId)
-	if err != nil {
-		return false, errors.Wrap(err, "could not retrieve module from port-id")
-	}
+	// if err != nil {
+	// 	return false, errors.Wrap(err, "could not retrieve module from port-id")
+	// }
 	if err := k.IbcKeeperFn().ChannelKeeper.WriteAcknowledgement(
 		ctx,
 		// chanCap,

--- a/x/swap/keeper/query_incoming_in_flight_packet.go
+++ b/x/swap/keeper/query_incoming_in_flight_packet.go
@@ -37,10 +37,13 @@ func (q queryServer) IncomingInFlightPacket(ctx context.Context, req *types.Quer
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	val, found := q.k.GetIncomingInFlightPacket(
+	val, found, err := q.k.GetIncomingInFlightPacket(
 		ctx,
 		req.SrcPortId, req.SrcChannelId, req.Sequence,
 	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "not found")
 	}

--- a/x/swap/keeper/query_outgoing_in_flight_packet.go
+++ b/x/swap/keeper/query_outgoing_in_flight_packet.go
@@ -37,12 +37,15 @@ func (q queryServer) OutgoingInFlightPacket(ctx context.Context, req *types.Quer
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	val, found := q.k.GetOutgoingInFlightPacket(
+	val, found, err := q.k.GetOutgoingInFlightPacket(
 		ctx,
 		req.SrcPortId,
 		req.SrcChannelId,
 		req.Sequence,
 	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "not found")
 	}

--- a/x/swap/keeper/store_incoming_in_flight_packet.go
+++ b/x/swap/keeper/store_incoming_in_flight_packet.go
@@ -9,15 +9,17 @@ import (
 )
 
 // SetIncomingInFlightPacket set a specific incomingPacket in the store from its index
-func (k Keeper) SetIncomingInFlightPacket(ctx context.Context, incomingPacket types.IncomingInFlightPacket) {
+func (k Keeper) SetIncomingInFlightPacket(ctx context.Context, incomingPacket types.IncomingInFlightPacket) error {
 	err := k.IncomingInFlightPackets.Set(
 		ctx,
 		types.IncomingInFlightPacketKey(incomingPacket.Index),
 		incomingPacket,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // GetIncomingInFlightPacket returns a incomingPacket from its index
@@ -26,26 +28,26 @@ func (k Keeper) GetIncomingInFlightPacket(
 	srcPortId string,
 	srcChannelId string,
 	sequence uint64,
-) (val types.IncomingInFlightPacket, found bool) {
+) (val types.IncomingInFlightPacket, found bool, err error) {
 	key := types.IncomingInFlightPacketKey(types.NewPacketIndex(srcPortId, srcChannelId, sequence))
 	has, err := k.IncomingInFlightPackets.Has(
 		ctx,
 		key,
 	)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
 	if !has {
-		return val, false
+		return val, false, nil
 	}
 
 	val, err = k.IncomingInFlightPackets.Get(ctx, key)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // RemoveIncomingInFlightPacket removes a incomingPacket from the store
@@ -54,19 +56,21 @@ func (k Keeper) RemoveIncomingInFlightPacket(
 	srcPortId string,
 	srcChannelId string,
 	sequence uint64,
-) {
+) error {
 	err := k.IncomingInFlightPackets.Remove(
 		ctx,
 		types.IncomingInFlightPacketKey(types.NewPacketIndex(srcPortId, srcChannelId, sequence)),
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // GetIncomingInFlightPackets returns all incomingPacket
-func (k Keeper) GetIncomingInFlightPackets(ctx context.Context) (list []types.IncomingInFlightPacket) {
-	err := k.IncomingInFlightPackets.Walk(
+func (k Keeper) GetIncomingInFlightPackets(ctx context.Context) (list []types.IncomingInFlightPacket, err error) {
+	err = k.IncomingInFlightPackets.Walk(
 		ctx,
 		nil,
 		func(key collections.Triple[string, string, uint64], value types.IncomingInFlightPacket) (bool, error) {
@@ -76,8 +80,8 @@ func (k Keeper) GetIncomingInFlightPackets(ctx context.Context) (list []types.In
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }

--- a/x/swap/keeper/store_outgoing_in_flight_packet.go
+++ b/x/swap/keeper/store_outgoing_in_flight_packet.go
@@ -9,15 +9,17 @@ import (
 )
 
 // SetOutgoingInFlightPacket set a specific outgoingInFlightPacket in the store from its index
-func (k Keeper) SetOutgoingInFlightPacket(ctx context.Context, outgoingInFlightPacket types.OutgoingInFlightPacket) {
+func (k Keeper) SetOutgoingInFlightPacket(ctx context.Context, outgoingInFlightPacket types.OutgoingInFlightPacket) error {
 	err := k.OutgoingInFlightPackets.Set(
 		ctx,
 		types.OutgoingInFlightPacketKey(outgoingInFlightPacket.Index),
 		outgoingInFlightPacket,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // OutgoingInFlightPacket returns a outgoingInFlightPacket from its index
@@ -26,26 +28,26 @@ func (k Keeper) GetOutgoingInFlightPacket(
 	srcPortId string,
 	srcChannelId string,
 	sequence uint64,
-) (val types.OutgoingInFlightPacket, found bool) {
+) (val types.OutgoingInFlightPacket, found bool, err error) {
 	key := types.OutgoingInFlightPacketKey(types.NewPacketIndex(srcPortId, srcChannelId, sequence))
 	has, err := k.OutgoingInFlightPackets.Has(
 		ctx,
 		key,
 	)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
 	if !has {
-		return val, false
+		return val, false, nil
 	}
 
 	val, err = k.OutgoingInFlightPackets.Get(ctx, key)
 	if err != nil {
-		panic(err)
+		return val, false, err
 	}
 
-	return val, true
+	return val, true, nil
 }
 
 // RemoveOutgoingInFlightPacket removes a outgoingInFlightPacket from the store
@@ -54,19 +56,21 @@ func (k Keeper) RemoveOutgoingInFlightPacket(
 	srcPortId string,
 	srcChannelId string,
 	sequence uint64,
-) {
+) error {
 	err := k.OutgoingInFlightPackets.Remove(
 		ctx,
 		types.OutgoingInFlightPacketKey(types.NewPacketIndex(srcPortId, srcChannelId, sequence)),
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // OutgoingInFlightPackets returns all outgoingInFlightPacket
-func (k Keeper) GetOutgoingInFlightPackets(ctx context.Context) (list []types.OutgoingInFlightPacket) {
-	err := k.OutgoingInFlightPackets.Walk(
+func (k Keeper) GetOutgoingInFlightPackets(ctx context.Context) (list []types.OutgoingInFlightPacket, err error) {
+	err = k.OutgoingInFlightPackets.Walk(
 		ctx,
 		nil,
 		func(key collections.Triple[string, string, uint64], value types.OutgoingInFlightPacket) (bool, error) {
@@ -76,8 +80,8 @@ func (k Keeper) GetOutgoingInFlightPackets(ctx context.Context) (list []types.Ou
 		},
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return
+	return list, nil
 }


### PR DESCRIPTION
close #197
close #199
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

1. Delete `panic(err)` in all store operations and return error
2. Add detailed error messages to x/liquidpool.
3. Fix [GetZkpThreshold bonded](https://github.com/sunriselayer/sunrise/pull/201/commits/0501719cdd14c8ef2d1cf8ff681c342bfd4b2517) to consider unbonded validators
4. Change [thoreshold](https://github.com/sunriselayer/sunrise/pull/201/commits/a0b71b56fc56621a90986777dfb94875e8712cd3) `TruncateInt()`
5. Add some Error handing

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
