### PR TITLE
fix: return nil instead of error directly

### DIFF
--- a/x/liquiditypool/types/tick.go
+++ b/x/liquiditypool/types/tick.go
@@ -155,5 +155,5 @@ func GetSqrtPriceFromQuoteBase(quoteAmount math.Int, baseAmount math.Int) (math.
 		return math.LegacyZeroDec(), err
 	}
 	sqrtPrice := sqrtPriceMultiplied.Quo(MultiplierSqrt)
-	return sqrtPrice, err
+	return sqrtPrice, nil
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The logic of err not being nil has been processed and returned before, so err must be nil here.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
