### PR TITLE
hotfix: nil map panic

### DIFF
--- a/x/da/keeper/abci.go
+++ b/x/da/keeper/abci.go
@@ -190,6 +190,9 @@ func (k Keeper) TallyValidityProofs(ctx sdk.Context, duration time.Duration, rep
 			for _, proof := range proofs {
 				for _, index := range proof.Indices {
 					shardProofCount[index]++
+					if shardProofSubmitted[index] == nil {
+						shardProofSubmitted[index] = make(map[string]bool)
+					}
 					shardProofSubmitted[index][proof.Sender] = true
 				}
 			}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This panic is caused by an attempt to assign a value to a nil map. 

```
panic: assignment to entry in nil map
goroutine 1 [running]:
github.com/sunriselayer/sunrise/x/da/keeper.Keeper.TallyValidityProofs({{{0x7963603afd98, 0xc00154bdc0}, {0x5759f78, 0x83de4e0}, {0x5741a00, 0xc000a326d0}, {0x5759fa0, 0x83de4e0}, {0x5741a20, 0x83de4e0}, ...}, ...}, ...)
```

The problem is that shardProofSubmitted[index] is a nil map. The outer map is initialized, but the inner map (map[string]bool) is not.
As a fix, the inner map must also be initialized as follows

This fix ensures that the inner map is initialized as needed and prevents panic.



<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
