### PR TITLE
feat: enable to create SendDisabled token pool from gov

### DIFF
--- a/x/liquiditypool/keeper/msg_server_create_pool.go
+++ b/x/liquiditypool/keeper/msg_server_create_pool.go
@@ -68,14 +68,14 @@ func (k msgServer) CreatePool(ctx context.Context, msg *types.MsgCreatePool) (*t
 
 	// end static validation
 
-	// Validate denom base and denom quote are sendable tokens
-	err = k.bankKeeper.IsSendEnabledCoins(ctx, sdk.NewCoin(msg.DenomBase, math.ZeroInt()), sdk.NewCoin(msg.DenomQuote, math.ZeroInt()))
-	if err != nil {
-		return nil, errorsmod.Wrap(err, "denom base and denom quote must be sendable tokens")
-	}
-
 	// Validate quote denom and consume gas if authority is not gov
 	if !sdk.AccAddress(sender).Equals(sdk.AccAddress(k.authority)) {
+		// Validate denom base and denom quote are sendable tokens
+		err = k.bankKeeper.IsSendEnabledCoins(ctx, sdk.NewCoin(msg.DenomBase, math.ZeroInt()), sdk.NewCoin(msg.DenomQuote, math.ZeroInt()))
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "denom base and denom quote must be sendable tokens")
+		}
+
 		feeDenom, err := k.feeKeeper.FeeDenom(ctx)
 		if err != nil {
 			return nil, errorsmod.Wrap(err, "failed to get fee denom")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Allow pool creation with `SendEnabled: false` tokens only via x/gov.

### Note 
This can only be bypassed by x/gov, so you need to set the VOTING PERIOD low at first or it will take days to create the pool.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
