### PR TITLE
fix: improve handling of incoming packet changes and forwards

### DIFF
--- a/x/swap/keeper/ibc.go
+++ b/x/swap/keeper/ibc.go
@@ -261,19 +261,23 @@ func (k Keeper) OnAcknowledgementOutgoingInFlightPacket(
 	}
 
 	// The pattern of waitingPacket.Return == nil is not handled here
-	switch incomingPacket.Change.(type) {
+	switch t := incomingPacket.Change.(type) {
 	case *types.IncomingInFlightPacket_OutgoingIndexChange:
-		incomingPacket.Change = &types.IncomingInFlightPacket_AckChange{
-			AckChange: acknowledgement,
+		if t.OutgoingIndexChange.Equal(outgoingPacket.Index) {
+			incomingPacket.Change = &types.IncomingInFlightPacket_AckChange{
+				AckChange: acknowledgement,
+			}
 		}
 		// case *types.IncomingInFlightPacket_AckChange:
 	}
 
 	// The pattern of waitingPacket.Forward == nil is not handled here
-	switch incomingPacket.Forward.(type) {
+	switch t := incomingPacket.Forward.(type) {
 	case *types.IncomingInFlightPacket_OutgoingIndexForward:
-		incomingPacket.Forward = &types.IncomingInFlightPacket_AckForward{
-			AckForward: acknowledgement,
+		if t.OutgoingIndexForward.Equal(outgoingPacket.Index) {
+			incomingPacket.Forward = &types.IncomingInFlightPacket_AckForward{
+				AckForward: acknowledgement,
+			}
 		}
 		// case *types.IncomingInFlightPacket_AckForward:
 	}


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This pull request addresses a critical bug that causes a `nil pointer dereference` panic within the `x/swap` module during the processing of IBC acknowledgements. The panic occurs in the `ShouldDeleteCompletedWaitingPacket` function, triggered by an incorrect state transition in `OnAcknowledgementOutgoingInFlightPacket`.

The root cause of the issue was that the `OnAcknowledgementOutgoingInFlightPacket` function did not properly distinguish between acknowledgements for `Change` packets (refunding remaining assets) and `Forward` packets (transferring swapped assets). As a result, receiving an acknowledgement for one packet could incorrectly mark the other as completed, leading to premature processing of the `IncomingInFlightPacket` and causing a panic when accessing nil data.

This fix ensures the integrity of the swap and forward process by preventing funds from getting stuck in an indeterminate state on the Sunrise chain, even though the funds themselves were never at risk of being lost.

### Problem

The core of the problem lies in the logic of `OnAcknowledgementOutgoingInFlightPacket`. When this function received an acknowledgement, it would check for the *existence* of an `OutgoingIndexChange` or `OutgoingIndexForward` packet but did not verify that the incoming acknowledgement actually corresponded to that specific packet.

For example, if a swap transaction involved both a `Forward` and a `Change` operation, an acknowledgement for the `Forward` packet would cause the function to incorrectly update the status of the `Change` packet as well. This led to the `ShouldDeleteCompletedWaitingPacket` function being called with an inconsistent state, where it expected acknowledgement data for the `Change` packet that was not yet available, resulting in a `nil pointer dereference`.

**Previous (Buggy) Logic:**
```go
// The function would enter this block as long as an OutgoingIndexChange existed,
// regardless of which packet the 'acknowledgement' was for.
switch incomingPacket.Change.(type) {
case *types.IncomingInFlightPacket_OutgoingIndexChange:
    incomingPacket.Change = &types.IncomingInFlightPacket_AckChange{
        AckChange: acknowledgement,
    }
}
```

This behavior left `IncomingInFlightPacket` entries stuck on-chain, as the transaction could never be successfully finalized.

### Solution

To resolve this issue, I have implemented a more stringent check within `OnAcknowledgementOutgoingInFlightPacket`, mirroring the logic already present in `OnTimeoutOutgoingInFlightPacket`.

The updated logic now explicitly compares the index of the packet that sent the acknowledgement (`outgoingPacket.Index`) with the indices stored in `OutgoingIndexChange` and `OutgoingIndexForward`. The status of a packet is now updated only if the indices match.

**Revised (Correct) Logic:**
```go
switch t := incomingPacket.Change.(type) {
case *types.IncomingInFlightPacket_OutgoingIndexChange:
    // Only update the status if the received ack matches the Change packet's index
    if t.OutgoingIndexChange.Equal(outgoingPacket.Index) {
        incomingPacket.Change = &types.IncomingInFlightPacket_AckChange{
            AckChange: acknowledgement,
        }
    }
}

switch t := incomingPacket.Forward.(type) {
case *types.IncomingInFlightPacket_OutgoingIndexForward:
    // Only update the status if the received ack matches the Forward packet's index
    if t.OutgoingIndexForward.Equal(outgoingPacket.Index) {
        incomingPacket.Forward = &types.IncomingInFlightPacket_AckForward{
            AckForward: acknowledgement,
        }
    }
}
```

This change ensures that each packet's lifecycle is managed independently and correctly, preventing state corruption and resolving the panic.

### Impact

- **Bug Fix:** Eliminates the `nil pointer dereference` panic.
- **State Consistency:** Guarantees that `IncomingInFlightPacket` entries are processed and cleaned up correctly upon receiving the proper acknowledgements.
- **Retroactive Cleanup:** After this upgrade is deployed, any packets that were previously stuck due to this bug will be correctly processed and cleared when the relayer submits the pending acknowledgements. No manual intervention is required.
- **No Fund Risk:** It's important to note that this bug did not put user funds at risk. The funds were successfully transferred to their destination; the error only occurred during the final confirmation step on the Sunrise chain.

This PR ensures a more robust and reliable IBC swap and forward functionality.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
