### PR TITLE
fix: x/cron integration & upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -74,7 +74,7 @@ import (
 	"github.com/sunriselayer/sunrise/app/gov"
 	"github.com/sunriselayer/sunrise/app/mint"
 
-	"github.com/sunriselayer/sunrise/app/upgrades/v1_1_0"
+	"github.com/sunriselayer/sunrise/app/upgrades/v1_2_0"
 )
 
 const (
@@ -467,8 +467,8 @@ func (app *App) setupUpgradeHandlers() {
 	// (which requires a PR) will take over with the new upgrade name defined below.
 	// For more information, see: https://docs.cosmos.network/main/tooling/cosmovisor
 	app.UpgradeKeeper.SetUpgradeHandler(
-		v1_1_0.UpgradeName,
-		v1_1_0.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.BankKeeper, app.LockupKeeper),
+		v1_2_0.UpgradeName,
+		v1_2_0.CreateUpgradeHandler(app.ModuleManager, app.Configurator()),
 	)
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
@@ -480,8 +480,8 @@ func (app *App) setupUpgradeHandlers() {
 		return
 	}
 
-	if upgradeInfo.Name == v1_1_0.UpgradeName {
+	if upgradeInfo.Name == v1_2_0.UpgradeName {
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &v1_1_0.StoreUpgrades))
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &v1_2_0.StoreUpgrades))
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,7 @@ type App struct {
 	SwapKeeper               swapmodulekeeper.Keeper
 	StableKeeper             stablemodulekeeper.Keeper
 	TokenfactoryKeeper       tokenfactorymodulekeeper.Keeper
-	CronKeeper               cronmodulekeeper.Keeper
+	CronKeeper               *cronmodulekeeper.Keeper
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
 
 	// simulation manager
@@ -265,6 +265,7 @@ func New(
 
 	// <sunrise>
 	app.SwapKeeper.TransferKeeper = &app.TransferKeeper
+	app.CronKeeper.WasmMsgServer = wasmkeeper.NewMsgServerImpl(&app.WasmKeeper)
 	// </sunrise>
 
 	// register streaming services

--- a/app/ibc.go
+++ b/app/ibc.go
@@ -267,10 +267,6 @@ func (app *App) registerWasmAndIBCModules(appOpts servertypes.AppOptions, nodeCo
 		return err
 	}
 
-	// <sunrise>
-	app.CronKeeper.SetWasmMsgServer(wasmkeeper.NewMsgServerImpl(&app.WasmKeeper))
-	// </sunrise>
-
 	return nil
 }
 

--- a/app/upgrades/v1_2_0/constants.go
+++ b/app/upgrades/v1_2_0/constants.go
@@ -1,0 +1,20 @@
+// This file defines the upgrade name for the v1.1.0 upgrade.
+package v1_2_0
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	crontypes "github.com/sunriselayer/sunrise/x/cron/types"
+	tokenfactorytypes "github.com/sunriselayer/sunrise/x/tokenfactory/types"
+)
+
+// UpgradeName is the name of the upgrade.
+const UpgradeName = "v1.2.0"
+
+// StoreUpgrades defines the store upgrades for the v1.1.0 upgrade.
+var StoreUpgrades = storetypes.StoreUpgrades{
+	Added: []string{
+		tokenfactorytypes.StoreKey,
+		crontypes.StoreKey,
+	},
+	Deleted: []string{},
+}

--- a/app/upgrades/v1_2_0/upgrade.go
+++ b/app/upgrades/v1_2_0/upgrade.go
@@ -1,0 +1,24 @@
+// This file contains the upgrade handler for the v1.2.0 upgrade.
+package v1_2_0
+
+import (
+	"context"
+	"fmt"
+
+	"cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+// CreateUpgradeHandler creates an upgrade handler for the v1.2.0 upgrade.
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) types.UpgradeHandler {
+	return func(goCtx context.Context, plan types.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(goCtx)
+		ctx.Logger().Info(fmt.Sprintf("update start:%s", UpgradeName))
+
+		return mm.RunMigrations(goCtx, configurator, fromVM)
+	}
+}

--- a/x/cron/keeper/keeper.go
+++ b/x/cron/keeper/keeper.go
@@ -226,6 +226,10 @@ func (k Keeper) getSchedulesReadyForExecution(ctx sdk.Context, executionStage ty
 // executeSchedule executes all msgs in a given schedule and changes LastExecuteHeight
 // if at least one msg execution fails, rollback all messages
 func (k Keeper) executeSchedule(ctx sdk.Context, schedule types.Schedule) error {
+	if k.WasmMsgServer == nil {
+		k.Logger().Info("WasmMsgServer is not set, skipping schedule execution")
+		return nil
+	}
 	// Even if contract execution returned an error, we still increase the height
 	// and execute it after this interval
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), LabelExecuteCronSchedule, schedule.Name)

--- a/x/cron/keeper/keeper.go
+++ b/x/cron/keeper/keeper.go
@@ -96,10 +96,6 @@ func (k Keeper) Logger() log.Logger {
 	return k.logger.With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-func (k *Keeper) SetWasmMsgServer(server types.WasmMsgServer) {
-	k.WasmMsgServer = server
-}
-
 // ExecuteReadySchedules gets all schedules that are due for execution (with limit that is equal to Params.Limit)
 // and executes messages in each one
 func (k Keeper) ExecuteReadySchedules(ctx sdk.Context, executionStage types.ExecutionStage) {

--- a/x/cron/module/depinject.go
+++ b/x/cron/module/depinject.go
@@ -41,7 +41,7 @@ type ModuleInputs struct {
 type ModuleOutputs struct {
 	depinject.Out
 
-	CronKeeper keeper.Keeper
+	CronKeeper *keeper.Keeper
 	Module     appmodule.AppModule
 }
 
@@ -59,7 +59,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.Logger,
 		in.AccountKeeper,
 	)
-	m := NewAppModule(in.Cdc, k, in.AccountKeeper)
+	m := NewAppModule(in.Cdc, &k, in.AccountKeeper)
 
-	return ModuleOutputs{CronKeeper: k, Module: m}
+	return ModuleOutputs{CronKeeper: &k, Module: m}
 }

--- a/x/cron/module/module.go
+++ b/x/cron/module/module.go
@@ -31,13 +31,13 @@ var (
 // AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement
 type AppModule struct {
 	cdc           codec.Codec
-	keeper        keeper.Keeper
+	keeper        *keeper.Keeper
 	accountKeeper types.AccountKeeper
 }
 
 func NewAppModule(
 	cdc codec.Codec,
-	keeper keeper.Keeper,
+	keeper *keeper.Keeper,
 	accountKeeper types.AccountKeeper,
 ) AppModule {
 	return AppModule{
@@ -74,8 +74,8 @@ func (AppModule) RegisterInterfaces(registrar codectypes.InterfaceRegistry) {
 
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(registrar grpc.ServiceRegistrar) error {
-	types.RegisterMsgServer(registrar, keeper.NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(registrar, keeper.NewQueryServerImpl(am.keeper))
+	types.RegisterMsgServer(registrar, keeper.NewMsgServerImpl(*am.keeper))
+	types.RegisterQueryServer(registrar, keeper.NewQueryServerImpl(*am.keeper))
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Using the pointer to manipulate the cron keeper enables the injection of WasmMsgServer later on.
This enables the initialization of `x/cron` using the same process as other modules.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
