### PR TITLE
feat: Prevent panic from nil pointer dereference in swap IBC handler

### DIFF
--- a/x/swap/keeper/ibc.go
+++ b/x/swap/keeper/ibc.go
@@ -263,7 +263,7 @@ func (k Keeper) OnAcknowledgementOutgoingInFlightPacket(
 	// The pattern of waitingPacket.Return == nil is not handled here
 	switch t := incomingPacket.Change.(type) {
 	case *types.IncomingInFlightPacket_OutgoingIndexChange:
-		if t.OutgoingIndexChange.Equal(outgoingPacket.Index) {
+		if t.OutgoingIndexChange != nil && t.OutgoingIndexChange.Equal(outgoingPacket.Index) {
 			incomingPacket.Change = &types.IncomingInFlightPacket_AckChange{
 				AckChange: acknowledgement,
 			}
@@ -274,7 +274,7 @@ func (k Keeper) OnAcknowledgementOutgoingInFlightPacket(
 	// The pattern of waitingPacket.Forward == nil is not handled here
 	switch t := incomingPacket.Forward.(type) {
 	case *types.IncomingInFlightPacket_OutgoingIndexForward:
-		if t.OutgoingIndexForward.Equal(outgoingPacket.Index) {
+		if t.OutgoingIndexForward != nil && t.OutgoingIndexForward.Equal(outgoingPacket.Index) {
 			incomingPacket.Forward = &types.IncomingInFlightPacket_AckForward{
 				AckForward: acknowledgement,
 			}
@@ -348,7 +348,7 @@ func (k Keeper) OnTimeoutOutgoingInFlightPacket(
 
 		switch packetReturn := waitingPacket.Change.(type) {
 		case *types.IncomingInFlightPacket_OutgoingIndexChange:
-			if packetReturn.OutgoingIndexChange.Equal(outgoingPacket.Index) {
+			if packetReturn.OutgoingIndexChange != nil && packetReturn.OutgoingIndexChange.Equal(outgoingPacket.Index) {
 				waitingPacket.Change = &types.IncomingInFlightPacket_AckChange{
 					AckChange: ack.Acknowledgement(),
 				}
@@ -358,7 +358,7 @@ func (k Keeper) OnTimeoutOutgoingInFlightPacket(
 
 		switch packetForward := waitingPacket.Forward.(type) {
 		case *types.IncomingInFlightPacket_OutgoingIndexForward:
-			if packetForward.OutgoingIndexForward.Equal(outgoingPacket.Index) {
+			if packetForward.OutgoingIndexForward != nil && packetForward.OutgoingIndexForward.Equal(outgoingPacket.Index) {
 				waitingPacket.Forward = &types.IncomingInFlightPacket_AckForward{
 					AckForward: ack.Acknowledgement(),
 				}
@@ -388,14 +388,14 @@ func (k Keeper) ShouldDeleteCompletedWaitingPacket(
 	switch packet.Change.(type) {
 	case *types.IncomingInFlightPacket_OutgoingIndexChange:
 		return false, nil
-	case *types.IncomingInFlightPacket_AckChange:
+	case *types.IncomingInFlightPacket_AckChange, nil:
 		break
 	}
 
 	switch packet.Forward.(type) {
 	case *types.IncomingInFlightPacket_OutgoingIndexForward:
 		return false, nil
-	case *types.IncomingInFlightPacket_AckForward:
+	case *types.IncomingInFlightPacket_AckForward, nil:
 		break
 	}
 

--- a/x/swap/keeper/ibc.go
+++ b/x/swap/keeper/ibc.go
@@ -402,12 +402,12 @@ func (k Keeper) ShouldDeleteCompletedWaitingPacket(
 	var changeAck []byte = nil
 	var forwardAck []byte = nil
 
-	if packet.Change != nil {
-		changeAck = packet.Change.(*types.IncomingInFlightPacket_AckChange).AckChange
+	if ack, ok := packet.Change.(*types.IncomingInFlightPacket_AckChange); ok && ack != nil {
+		changeAck = ack.AckChange
 	}
 
-	if packet.Forward != nil {
-		forwardAck = packet.Forward.(*types.IncomingInFlightPacket_AckForward).AckForward
+	if ack, ok := packet.Forward.(*types.IncomingInFlightPacket_AckForward); ok && ack != nil {
+		forwardAck = ack.AckForward
 	}
 
 	fullAck := types.SwapAcknowledgement{


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR addresses a runtime panic (`invalid memory address or nil pointer dereference`) that occurs during the handling of IBC packet acknowledgements and timeouts in the `x/swap` module.

### Problem

The panic was triggered by unsafe type assertions and method calls on potentially `nil` fields within the IBC handler logic. The stack trace pointed to `ShouldDeleteCompletedWaitingPacket`, but further investigation revealed similar potential issues in `OnAcknowledgementOutgoingInFlightPacket` and `OnTimeoutOutgoingInFlightPacket`.

The key issues were:
1.  Unsafe type assertions like `packet.Change.(*types.IncomingInFlightPacket_AckChange)` could panic if the `oneof` field was not of the expected type, even if it wasn't `nil`.
2.  Method calls like `t.OutgoingIndexChange.Equal(...)` would panic if `t.OutgoingIndexChange` was `nil`.
3.  `switch` statements did not explicitly handle `nil` cases for `oneof` fields, which could lead to unexpected behavior if the field was not set.

### Solution

This PR introduces several changes to make the IBC handling logic more robust and prevent panics:

1.  **Safe Type Assertions:** Replaced direct type assertions in `ShouldDeleteCompletedWaitingPacket` with the `if ack, ok := ...` pattern to safely check the type and value of `packet.Change` and `packet.Forward` before accessing their fields.
2.  **Nil Checks:** Added explicit `nil` checks in `OnAcknowledgementOutgoingInFlightPacket` and `OnTimeoutOutgoingInFlightPacket` before calling the `.Equal()` method on `OutgoingIndexChange` and `OutgoingIndexForward` fields.
3.  **Improved Switch Logic:** Updated the `switch` statements in `ShouldDeleteCompletedWaitingPacket` to explicitly handle the `nil` case for `packet.Change` and `packet.Forward`, treating it as a completed state similar to `AckChange`/`AckForward`.

These changes ensure that the packet handling logic is resilient to unexpected states and prevents the node from crashing, improving the overall stability of the swap module.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
