### PR TITLE
[pr-shadow] #309: chore: simplify metadata splitter definition

### DIFF
--- a/app/abci_proposal.go
+++ b/app/abci_proposal.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sunriselayer/sunrise/x/da/types"
 )
 
-var metadataUriSplitter = []byte{0x4D, 0x45, 0x54, 0x41, 0x44, 0x41, 0x54, 0x41} // ASCII for "METADATA"
+var metadataUriSplitter = []byte("METADATA")
 
 func getSplitterIndex(txs [][]byte) int {
 	for i, txBytes := range txs {


### PR DESCRIPTION
<!-- PR_SHADOW_ORIGINAL: sunriselayer/sunrise#309 -->
<!-- PR_SHADOW_MANAGED -->

This pull request is an automated [pr-shadow](https://github.com/Senna46/pr-shadow) mirror of #309.

Cursor Bugbot (Individual) only reviews PRs authored by @Senna46. This mirror exists so Bugbot and Fixooly can run.

**Do not merge this PR into the default branch.** pr-shadow will retarget it or close it automatically.

Original author: @operagxoksana
Original: https://github.com/sunriselayer/sunrise/pull/309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Readability-only change with identical byte content; no logic or consensus behavior change.
> 
> **Overview**
> Replaces the explicit ASCII hex byte slice for `metadataUriSplitter` with `[]byte("METADATA")` in `app/abci_proposal.go`.
> 
> The splitter still marks where verified DA metadata URIs begin in proposal/finalize tx lists; only the definition style changes, not the bytes or ABCI handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2259a6f00db2bd755d6e676d0b7cf50796f58e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->